### PR TITLE
Eliminate user retries on pod setup resumes (Loop issue #2117 follow up)

### DIFF
--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -888,6 +888,7 @@ extension OmniBLEPumpManager {
                     self.podComms.pairAndSetupPod(timeZone: .currentFixed, insulinType: insulinType, messageLogger: self)
                     { (result) in
 
+                        // Have new podState, reset all the per pod pump manager state
                         self.resetPerPodPumpManagerState()
 
                         // Calls completion
@@ -904,7 +905,6 @@ extension OmniBLEPumpManager {
             self.resumingPodSetup()
 
             self.podComms.runSession(withName: "Prime pod") { (result) in
-
                 // Calls completion
                 primeSession(result)
             }

--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -920,10 +920,10 @@ extension OmniBLEPumpManager {
         let mockFaultDuringInsertCannula = false
         DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + mockDelay) {
             let result = self.setStateWithResult({ (state) -> Result<TimeInterval,OmniBLEPumpManagerError> in
-            if mockFaultDuringInsertCannula {
-                let fault = try! DetailedStatus(encodedData: Data(hexadecimalString: "020d0000000e00c36a020703ff020900002899080082")!)
-                var podState = state.podState
-                podState?.fault = fault
+                if mockFaultDuringInsertCannula {
+                    let fault = try! DetailedStatus(encodedData: Data(hexadecimalString: "020d0000000e00c36a020703ff020900002899080082")!)
+                    var podState = state.podState
+                    podState?.fault = fault
                     state.updatePodStateFromPodComms(podState)
                     return .failure(OmniBLEPumpManagerError.communication(PodCommsError.podFault(fault: fault)))
                 }

--- a/OmniBLE/PumpManagerUI/ViewModels/InsertCannulaViewModel.swift
+++ b/OmniBLE/PumpManagerUI/ViewModels/InsertCannulaViewModel.swift
@@ -129,6 +129,7 @@ class InsertCannulaViewModel: ObservableObject, Identifiable {
     }
 
     @Published var state: InsertCannulaViewModelState = .ready
+
     public var stateNeedsDeliberateUserAcceptance : Bool {
         switch state {
         case .ready:
@@ -143,16 +144,19 @@ class InsertCannulaViewModel: ObservableObject, Identifiable {
     var didRequestDeactivation: (() -> Void)?
     
     var cannulaInserter: CannulaInserter
-    
+
+    var autoRetryAttempted: Bool
+
     init(cannulaInserter: CannulaInserter) {
         self.cannulaInserter = cannulaInserter
+        self.autoRetryAttempted = false
 
         // If resuming, don't wait for the button action
         if cannulaInserter.cannulaInsertionSuccessfullyStarted {
             insertCannula()
         }
     }
-    
+
     private func checkCannulaInsertionFinished() {
         state = .checkingInsertion
         cannulaInserter.checkCannulaInsertionFinished() { (error) in
@@ -168,6 +172,7 @@ class InsertCannulaViewModel: ObservableObject, Identifiable {
     
     private func insertCannula() {
         state = .startingInsertion
+
         cannulaInserter.insertCannula { (result) in
             DispatchQueue.main.async {
                 switch(result) {
@@ -182,7 +187,19 @@ class InsertCannulaViewModel: ObservableObject, Identifiable {
                         self.state = .finished
                     }
                 case .failure(let error):
-                    self.state = .error(error)
+                    if self.autoRetryAttempted {
+                        self.autoRetryAttempted = false // allow for an auto retry on the next user attempt
+                        self.state = .error(error)
+                    } else {
+                        self.autoRetryAttempted = true
+                        let autoRetryPauseTime = TimeInterval(seconds: 3)
+                        print("### insertCannula encountered error \(error.localizedDescription), retrying after \(autoRetryPauseTime) seconds")
+                        DispatchQueue.global(qos: .utility).async {
+                            Thread.sleep(forTimeInterval: autoRetryPauseTime)
+
+                            self.insertCannula()
+                        }
+                    }
                 }
             }
         }

--- a/OmniBLE/PumpManagerUI/ViewModels/PairPodViewModel.swift
+++ b/OmniBLE/PumpManagerUI/ViewModels/PairPodViewModel.swift
@@ -168,8 +168,11 @@ class PairPodViewModel: ObservableObject, Identifiable {
 
     var podPairer: PodPairer
 
+    var autoRetryAttempted: Bool
+
     init(podPairer: PodPairer) {
         self.podPairer = podPairer
+        self.autoRetryAttempted = false
 
         // If resuming, don't wait for the button action
         if podPairer.podCommState == .activating {
@@ -189,8 +192,20 @@ class PairPodViewModel: ObservableObject, Identifiable {
             DispatchQueue.main.async {
                 switch status {
                 case .failure(let error):
-                    let pairingError = DashPairingError.pumpManagerError(error)
-                    self.state = .error(pairingError)
+                    if self.autoRetryAttempted {
+                        self.autoRetryAttempted = false // allow for an auto retry on the next user attempt
+                        let pairAndPrimeError = DashPairingError.pumpManagerError(error)
+                        self.state = .error(pairAndPrimeError)
+                    } else {
+                        self.autoRetryAttempted = true
+                        let autoRetryPauseTime = TimeInterval(seconds: 3)
+                        print("### pairAndPrimePod encountered error \(error.localizedDescription), retrying after \(autoRetryPauseTime) seconds")
+                        DispatchQueue.global(qos: .utility).async {
+                            Thread.sleep(forTimeInterval: autoRetryPauseTime)
+
+                            self.pairAndPrime() // handles both pairing or priming failures
+                        }
+                    }
                 case .success(let duration):
                     
                     if duration > 0 {


### PR DESCRIPTION
* Have PairAndPrime ViewModel do an automatic retry on error
* Have InsertCannula ViewModel do an automatic retry on error
* Add resumingPodSetup func to attempt a getStatus and sleep on errors
* Added some improved and updated pumpManager comments
* Have pumpManager detect pod setup resumes to invoke resumingPodSetup()
* Include additional isConnected handling to OmniBLE resumingPodSetup()