### PR TITLE
Draft for LoopKit PR: add Silent Pod, Pod Diagnostic features and support

### DIFF
--- a/OmniBLE.xcodeproj/project.pbxproj
+++ b/OmniBLE.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		10389A4126FF7841002115E9 /* MessageTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10389A2226FF7841002115E9 /* MessageTransport.swift */; };
 		2742C7052AD875B100E67833 /* SlideButton in Frameworks */ = {isa = PBXBuildFile; productRef = 2742C7042AD875B100E67833 /* SlideButton */; };
 		4B67E2D5289B4EDB002D92AF /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 4B67E2D3289B4EDB002D92AF /* Localizable.strings */; };
+		196A6F232AFFFD1700E3C089 /* SilencePodPreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 196A6F222AFFFD1200E3C089 /* SilencePodPreference.swift */; };
 		84752E9326ED0FFE009FD801 /* OmniBLE.h in Headers */ = {isa = PBXBuildFile; fileRef = 84752E8526ED0FFE009FD801 /* OmniBLE.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		84752ED626ED13F5009FD801 /* Id.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84752EBF26ED13F5009FD801 /* Id.swift */; };
 		84752ED726ED13F5009FD801 /* X25519KeyGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84752EC126ED13F5009FD801 /* X25519KeyGenerator.swift */; };
@@ -168,6 +169,14 @@
 		D802CD0A27DD98C10072E3A1 /* TempBasalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802CD0527DD98C10072E3A1 /* TempBasalTests.swift */; };
 		D802CD1027DD99AB0072E3A1 /* CRC16Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802CD0F27DD99AB0072E3A1 /* CRC16Tests.swift */; };
 		D802CD1227DD9AE10072E3A1 /* BasalScheduleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802CD1127DD9AE10072E3A1 /* BasalScheduleTests.swift */; };
+		D845A1372AF89F5500EA0853 /* ActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D845A1362AF89F5500EA0853 /* ActivityView.swift */; };
+		D845A1392AF89F6300EA0853 /* FirstAppear.swift in Sources */ = {isa = PBXBuildFile; fileRef = D845A1382AF89F6300EA0853 /* FirstAppear.swift */; };
+		D845A13B2AF89F7100EA0853 /* PlayTestBeepsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D845A13A2AF89F7100EA0853 /* PlayTestBeepsView.swift */; };
+		D845A13F2AF89F8400EA0853 /* ReadPodStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D845A13C2AF89F8400EA0853 /* ReadPodStatusView.swift */; };
+		D845A1412AF89F8400EA0853 /* PumpManagerDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D845A13E2AF89F8400EA0853 /* PumpManagerDetailsView.swift */; };
+		D845A1432AF89F9200EA0853 /* SilencePodSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D845A1422AF89F9200EA0853 /* SilencePodSelectionView.swift */; };
+		D85AEABC2B12D76F00081044 /* PodDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85AEABB2B12D76F00081044 /* PodDiagnostics.swift */; };
+		D85AEAC42B13083F00081044 /* ReadPodInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85AEAC32B13083F00081044 /* ReadPodInfoView.swift */; };
 		D8896C6227890E6B00E09A96 /* DetailedStatus+OmniBLE.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8896C6127890E6B00E09A96 /* DetailedStatus+OmniBLE.swift */; };
 		D895BF5B275DE64000D51FC7 /* StringLengthPrefixEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = D895BF5A275DE64000D51FC7 /* StringLengthPrefixEncoding.swift */; };
 		D897B06B29347ED500FDB009 /* BolusDeliveryTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D897B06A29347ED500FDB009 /* BolusDeliveryTable.swift */; };
@@ -314,6 +323,7 @@
 		10389A1D26FF7841002115E9 /* Message.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		10389A2026FF7841002115E9 /* CRC16.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CRC16.swift; sourceTree = "<group>"; };
 		10389A2226FF7841002115E9 /* MessageTransport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageTransport.swift; sourceTree = "<group>"; };
+		196A6F222AFFFD1200E3C089 /* SilencePodPreference.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SilencePodPreference.swift; sourceTree = "<group>"; };
 		4B23AA6328D909E2009B453B /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4B23AA6428D909E7009B453B /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		4B23AA6528D909E9009B453B /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -444,6 +454,14 @@
 		D802CD0527DD98C10072E3A1 /* TempBasalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TempBasalTests.swift; sourceTree = "<group>"; };
 		D802CD0F27DD99AB0072E3A1 /* CRC16Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CRC16Tests.swift; sourceTree = "<group>"; };
 		D802CD1127DD9AE10072E3A1 /* BasalScheduleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasalScheduleTests.swift; sourceTree = "<group>"; };
+		D845A1362AF89F5500EA0853 /* ActivityView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityView.swift; sourceTree = "<group>"; };
+		D845A1382AF89F6300EA0853 /* FirstAppear.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FirstAppear.swift; sourceTree = "<group>"; };
+		D845A13A2AF89F7100EA0853 /* PlayTestBeepsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlayTestBeepsView.swift; sourceTree = "<group>"; };
+		D845A13C2AF89F8400EA0853 /* ReadPodStatusView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadPodStatusView.swift; sourceTree = "<group>"; };
+		D845A13E2AF89F8400EA0853 /* PumpManagerDetailsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PumpManagerDetailsView.swift; sourceTree = "<group>"; };
+		D845A1422AF89F9200EA0853 /* SilencePodSelectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SilencePodSelectionView.swift; sourceTree = "<group>"; };
+		D85AEABB2B12D76F00081044 /* PodDiagnostics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PodDiagnostics.swift; sourceTree = "<group>"; };
+		D85AEAC32B13083F00081044 /* ReadPodInfoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadPodInfoView.swift; sourceTree = "<group>"; };
 		D8896C6127890E6B00E09A96 /* DetailedStatus+OmniBLE.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DetailedStatus+OmniBLE.swift"; sourceTree = "<group>"; };
 		D895BF5A275DE64000D51FC7 /* StringLengthPrefixEncoding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringLengthPrefixEncoding.swift; sourceTree = "<group>"; };
 		D897B06A29347ED500FDB009 /* BolusDeliveryTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BolusDeliveryTable.swift; sourceTree = "<group>"; };
@@ -511,6 +529,7 @@
 				1016325627185EE4007A3BC2 /* PodProgressStatus.swift */,
 				C1F67ED927979E400017487F /* PumpManagerAlert.swift */,
 				C1F67EE127985F580017487F /* ReservoirLevel.swift */,
+				196A6F222AFFFD1200E3C089 /* SilencePodPreference.swift */,
 				1016325827185EE4007A3BC2 /* UnfinalizedDose.swift */,
 			);
 			path = OmnipodCommon;
@@ -746,6 +765,7 @@
 		8475311E26ED838A009FD801 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				D845A1362AF89F5500EA0853 /* ActivityView.swift */,
 				C1F67E7327975B830017487F /* AttachPodView.swift */,
 				C1F67E7A27975B830017487F /* BasalStateView.swift */,
 				C1ED1E7127BAE44E00FED71C /* BeepPreferenceSelectionView.swift */,
@@ -755,6 +775,7 @@
 				C1F67EB227975E710017487F /* DesignElements */,
 				C1F67E7B27975B830017487F /* ExpirationReminderPickerView.swift */,
 				C1F67E7827975B830017487F /* ExpirationReminderSetupView.swift */,
+				D845A1382AF89F6300EA0853 /* FirstAppear.swift */,
 				C1F67E7D27975B830017487F /* HUDAssets.xcassets */,
 				C1F67E8527975B830017487F /* InsertCannulaView.swift */,
 				C187C190278FCEC9006E3557 /* InsulinTypeConfirmation.swift */,
@@ -766,10 +787,16 @@
 				C1C001C227A2351D00533D35 /* OmniBLEReservoirView.xib */,
 				C1F67E7727975B830017487F /* OmniBLESettingsView.swift */,
 				C1F67E7F27975B830017487F /* PairPodView.swift */,
+				D845A13A2AF89F7100EA0853 /* PlayTestBeepsView.swift */,
 				C1F67E8A27975B830017487F /* PodDetailsView.swift */,
+				D85AEABB2B12D76F00081044 /* PodDiagnostics.swift */,
 				C1F67E8827975B830017487F /* PodSetupView.swift */,
+				D845A13E2AF89F8400EA0853 /* PumpManagerDetailsView.swift */,
+				D85AEAC32B13083F00081044 /* ReadPodInfoView.swift */,
+				D845A13C2AF89F8400EA0853 /* ReadPodStatusView.swift */,
 				C1F67E7427975B830017487F /* ScheduledExpirationReminderEditView.swift */,
 				C1F67E8727975B830017487F /* SetupCompleteView.swift */,
+				D845A1422AF89F9200EA0853 /* SilencePodSelectionView.swift */,
 				C1F67E7627975B830017487F /* TimeView.swift */,
 				C1F67E8427975B830017487F /* UncertaintyRecoveredView.swift */,
 			);
@@ -1120,7 +1147,9 @@
 				1029AE4927094D0E00B7F5B6 /* OmniBLEPumpManagerState.swift in Sources */,
 				10289E7D2739F893000339E6 /* Milenage.swift in Sources */,
 				10389A3A26FF7841002115E9 /* SetInsulinScheduleCommand.swift in Sources */,
+				D845A13B2AF89F7100EA0853 /* PlayTestBeepsView.swift in Sources */,
 				10389A3826FF7841002115E9 /* DetailedStatus.swift in Sources */,
+				D85AEABC2B12D76F00081044 /* PodDiagnostics.swift in Sources */,
 				C1F67E9927975B830017487F /* NotificationSettingsView.swift in Sources */,
 				10389A2B26FF7841002115E9 /* PlaceholderMessageBlock.swift in Sources */,
 				10389A3026FF7841002115E9 /* StatusResponse.swift in Sources */,
@@ -1142,6 +1171,7 @@
 				10389A3126FF7841002115E9 /* GetStatusCommand.swift in Sources */,
 				C1C001BF27A2337B00533D35 /* PeripheralManager+OmniBLE.swift in Sources */,
 				10389A3F26FF7841002115E9 /* CRC16.swift in Sources */,
+				D85AEAC42B13083F00081044 /* ReadPodInfoView.swift in Sources */,
 				10289E68271B2A08000339E6 /* NumberFormatter.swift in Sources */,
 				1016325927185EE4007A3BC2 /* BeepType.swift in Sources */,
 				C1F67E9E27975B830017487F /* LowReservoirReminderEditView.swift in Sources */,
@@ -1163,6 +1193,7 @@
 				C1ED1E7227BAE44E00FED71C /* BeepPreferenceSelectionView.swift in Sources */,
 				84752EDE26ED13F5009FD801 /* PeripheralManagerError.swift in Sources */,
 				10389A2526FF7841002115E9 /* PodInfoActivationTime.swift in Sources */,
+				D845A1432AF89F9200EA0853 /* SilencePodSelectionView.swift in Sources */,
 				C1F67E9A27975B830017487F /* DeliveryUncertaintyRecoveryView.swift in Sources */,
 				1021114D2709467400784F13 /* PodComms.swift in Sources */,
 				10289E6E27309327000339E6 /* CBPeripheral.swift in Sources */,
@@ -1181,6 +1212,7 @@
 				1016325C27185EE5007A3BC2 /* BasalDeliveryTable.swift in Sources */,
 				84752EE326ED13F5009FD801 /* BLEPacket.swift in Sources */,
 				102111472709462300784F13 /* PodState.swift in Sources */,
+				196A6F232AFFFD1700E3C089 /* SilencePodPreference.swift in Sources */,
 				1021114B2709462300784F13 /* BasalSchedule+LoopKit.swift in Sources */,
 				84752EE626ED13F5009FD801 /* LTKExchanger.swift in Sources */,
 				10389A2A26FF7841002115E9 /* MessageBlock.swift in Sources */,
@@ -1189,6 +1221,7 @@
 				C1F67E9227975B830017487F /* BasalStateView.swift in Sources */,
 				1024E32B27446DB000DE01F2 /* MessagePacket.swift in Sources */,
 				10289E7B2739F886000339E6 /* EapMessage.swift in Sources */,
+				D845A1392AF89F6300EA0853 /* FirstAppear.swift in Sources */,
 				C1C001C127A2349D00533D35 /* OmniBLE.swift in Sources */,
 				10389A3326FF7841002115E9 /* CancelDeliveryCommand.swift in Sources */,
 				C1DBD513282FF79D009FCF74 /* ManualTempBasalEntryView.swift in Sources */,
@@ -1196,6 +1229,7 @@
 				C1F67EA027975B830017487F /* PodSetupView.swift in Sources */,
 				C1ED1E7027BAE1A600FED71C /* BeepPreference.swift in Sources */,
 				10389A3B26FF7841002115E9 /* ConfigureAlertsCommand.swift in Sources */,
+				D845A13F2AF89F8400EA0853 /* ReadPodStatusView.swift in Sources */,
 				D8896C6227890E6B00E09A96 /* DetailedStatus+OmniBLE.swift in Sources */,
 				10389A3926FF7841002115E9 /* PodInfoResponse.swift in Sources */,
 				84752EE226ED13F5009FD801 /* PayloadJoiner.swift in Sources */,
@@ -1205,6 +1239,7 @@
 				C1F67EC827975F360017487F /* DeactivatePodViewModel.swift in Sources */,
 				C1F67E9127975B830017487F /* DeactivatePodView.swift in Sources */,
 				84752EE726ED13F5009FD801 /* PairResult.swift in Sources */,
+				D845A1412AF89F8400EA0853 /* PumpManagerDetailsView.swift in Sources */,
 				8475315D26EDA193009FD801 /* Data.swift in Sources */,
 				C1F67E9427975B830017487F /* LowReservoirReminderSetupView.swift in Sources */,
 				C1F67EB627975E710017487F /* RoundedCard.swift in Sources */,
@@ -1222,6 +1257,7 @@
 				10389A2E26FF7841002115E9 /* FaultConfigCommand.swift in Sources */,
 				C1F67E9F27975B830017487F /* SetupCompleteView.swift in Sources */,
 				C1F67EE227985F580017487F /* ReservoirLevel.swift in Sources */,
+				D845A1372AF89F5500EA0853 /* ActivityView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OmniBLE/Bluetooth/PodProtocolError.swift
+++ b/OmniBLE/Bluetooth/PodProtocolError.swift
@@ -1,6 +1,6 @@
 //
 //  PodProtocolError.swift
-//  OmnipodKit
+//  OmniBLE
 //
 //  Created by Randall Knutson on 8/3/21.
 //

--- a/OmniBLE/OmnipodCommon/AlertSlot.swift
+++ b/OmniBLE/OmnipodCommon/AlertSlot.swift
@@ -9,9 +9,27 @@
 
 import Foundation
 
+fileprivate let defaultShutdownImminentTime = Pod.serviceDuration - Pod.endOfServiceImminentWindow
+fileprivate let defaultExpirationReminderTime = Pod.nominalPodLife - Pod.defaultExpirationReminderOffset
+fileprivate let defaultExpiredTime = Pod.nominalPodLife
+
+// PDM and pre-SwiftUI use every1MinuteFor3MinutesAndRepeatEvery15Minutes, but with SwiftUI use every15Minutes
+fileprivate let suspendTimeExpiredBeepRepeat = BeepRepeat.every15Minutes
+
 public enum AlertTrigger {
     case unitsRemaining(Double)
     case timeUntilAlert(TimeInterval)
+}
+
+extension AlertTrigger: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        switch self {
+        case .unitsRemaining(let units):
+            return "\(Int(units))U"
+        case .timeUntilAlert(let triggerTime):
+            return "triggerTime=\(triggerTime.timeIntervalStr)"
+        }
+    }
 }
 
 public enum BeepRepeat: UInt8 {
@@ -30,29 +48,48 @@ public enum BeepRepeat: UInt8 {
 public struct AlertConfiguration {
 
     let slot: AlertSlot
-    let trigger: AlertTrigger
     let active: Bool
     let duration: TimeInterval
+    let trigger: AlertTrigger
     let beepRepeat: BeepRepeat
     let beepType: BeepType
+    let silent: Bool
     let autoOffModifier: Bool
 
     static let length = 6
 
-    public init(alertType: AlertSlot, active: Bool = true, autoOffModifier: Bool = false, duration: TimeInterval, trigger: AlertTrigger, beepRepeat: BeepRepeat, beepType: BeepType) {
+    public init(alertType: AlertSlot, active: Bool = true, duration: TimeInterval = 0, trigger: AlertTrigger, beepRepeat: BeepRepeat, beepType: BeepType, silent: Bool, autoOffModifier: Bool = false)
+    {
         self.slot = alertType
         self.active = active
-        self.autoOffModifier = autoOffModifier
         self.duration = duration
         self.trigger = trigger
         self.beepRepeat = beepRepeat
         self.beepType = beepType
+        self.silent = silent
+        self.autoOffModifier = autoOffModifier
     }
 }
 
 extension AlertConfiguration: CustomDebugStringConvertible {
     public var debugDescription: String {
-        return "AlertConfiguration(slot:\(slot), active:\(active), autoOffModifier:\(autoOffModifier), duration:\(duration), trigger:\(trigger), beepRepeat:\(beepRepeat), beepType:\(beepType))"
+        var str = "slot:\(slot)"
+        if !active {
+            str += ", active:\(active)"
+        }
+        if duration != 0 {
+            str += ", duration:\(duration.timeIntervalStr)"
+        }
+        str += ", trigger:\(trigger), beepRepeat:\(beepRepeat)"
+        if beepType != .noBeepNonCancel {
+            str += ", beepType:\(beepType)"
+        } else {
+            str += ", silent:\(silent)"
+        }
+        if autoOffModifier {
+            str += ", autoOffModifier:\(autoOffModifier)"
+        }
+        return "\nAlertConfiguration(\(str))"
     }
 }
 
@@ -61,54 +98,73 @@ extension AlertConfiguration: CustomDebugStringConvertible {
 public enum PodAlert: CustomStringConvertible, RawRepresentable, Equatable {
     public typealias RawValue = [String: Any]
 
-    // 2 hours long, time for user to start pairing process
+    // slot0AutoOff: auto-off timer; requires user input every x minutes -- NOT IMPLEMENTED
+    case autoOff(active: Bool, offset: TimeInterval, countdownDuration: TimeInterval, silent: Bool = false)
+
+    // slot1NotUsed
+    case notUsed
+
+    // slot2ShutdownImminent: 79 hour alarm (1 hour before shutdown)
+    // 2 sets of beeps every 15 minutes for 1 hour
+    case shutdownImminent(offset: TimeInterval, absAlertTime: TimeInterval, silent: Bool = false)
+
+    // slot3ExpirationReminder: User configurable with PDM (1-24 hours before 72 hour expiration)
+    // 2 sets of beeps every minute for 3 minutes and repeat every 15 minutes
+    // The PDM doesn't use a duration for this alert (presumably because it is limited to 2^9-1 minutes or 8h31m)
+    case expirationReminder(offset: TimeInterval, absAlertTime: TimeInterval, duration: TimeInterval = 0, silent: Bool = false)
+
+    // slot4LowReservoir: reservoir below configured value alert
+    case lowReservoir(units: Double, silent: Bool = false)
+
+    // slot5SuspendedReminder: pod suspended reminder, before suspendTime;
+    // short beep every 15 minutes if > 30 min, else short beep every 5 minutes
+    case podSuspendedReminder(active: Bool, offset: TimeInterval, suspendTime: TimeInterval, timePassed: TimeInterval = 0, silent: Bool = false)
+
+    // slot6SuspendTimeExpired: pod suspend time expired alarm, after suspendTime;
+    // 2 sets of beeps every minute for 3 minutes repeated every 15 minutes (PDM & pre-SwiftUI implementations)
+    // 2 sets of beeps every 15 minutes (for SwiftUI PumpManagerAlerts implementations)
+    case suspendTimeExpired(offset: TimeInterval, suspendTime: TimeInterval, silent: Bool = false)
+
+    // slot7Expired: 2 hours long, time for user to start pairing process
     case waitingForPairingReminder
 
-    // 1 hour long, time for user to finish priming, cannula insertion
+    // slot7Expired: 1 hour long, time for user to finish priming, cannula insertion
     case finishSetupReminder
 
-    // User configurable with PDM (1-24 hours before 72 hour expiration) "Change Pod Soon"
-    case expirationReminder(TimeInterval)
-
-    // 72 hour alarm
-    case expired(alertTime: TimeInterval, duration: TimeInterval)
-
-    // 79 hour alarm (1 hour before shutdown)
-    case shutdownImminent(TimeInterval)
-
-    // reservoir below configured value alert
-    case lowReservoir(Double)
-
-    // auto-off timer; requires user input every x minutes
-    case autoOff(active: Bool, countdownDuration: TimeInterval)
-
-    // pod suspended reminder, before suspendTime; short beep every 15 minutes if > 30 min, else every 5 minutes
-    case podSuspendedReminder(active: Bool, suspendTime: TimeInterval)
-
-    // pod suspend time expired alarm, after suspendTime; 2 sets of beeps every min for 3 minutes repeated every 15 minutes
-    case suspendTimeExpired(suspendTime: TimeInterval)
+    // slot7Expired: 72 hour alarm
+    case expired(offset: TimeInterval, absAlertTime: TimeInterval, duration: TimeInterval, silent: Bool = false)
 
     public var description: String {
         var alertName: String
         switch self {
-        case .waitingForPairingReminder:
-            return LocalizedString("Waiting for pairing reminder", comment: "Description waiting for pairing reminder")
-        case .finishSetupReminder:
-            return LocalizedString("Finish setup reminder", comment: "Description for finish setup reminder")
-        case .expirationReminder:
-            alertName = LocalizedString("Expiration alert", comment: "Description for expiration alert")
-        case .expired:
-            alertName = LocalizedString("Expiration advisory", comment: "Description for expiration advisory")
-        case .shutdownImminent:
-            alertName = LocalizedString("Shutdown imminent", comment: "Description for shutdown imminent")
-        case .lowReservoir(let units):
-            alertName = String(format: LocalizedString("Low reservoir advisory (%1$gU)", comment: "Format string for description for low reservoir advisory (1: reminder units)"), units)
+        // slot0AutoOff
         case .autoOff:
-            alertName = LocalizedString("Auto-off", comment: "Description for auto-off")
+            alertName = LocalizedString("Auto-off", comment: "Description for auto-off alert")
+        // slot1NotUsed
+        case .notUsed:
+            alertName = LocalizedString("Not used", comment: "Description for not used slot alert")
+        // slot2ShutdownImminent
+        case .shutdownImminent:
+            alertName = LocalizedString("Shutdown imminent", comment: "Description for shutdown imminent alert")
+        // slot3ExpirationReminder
+        case .expirationReminder:
+            alertName = LocalizedString("Expiration reminder", comment: "Description for expiration reminder alert")
+        // slot4LowReservoir
+        case .lowReservoir:
+            alertName = LocalizedString("Low reservoir", comment: "Format string for description for low reservoir alert")
+        // slot5SuspendedReminder
         case .podSuspendedReminder:
-            alertName = LocalizedString("Pod suspended reminder", comment: "Description for pod suspended reminder")
+            alertName = LocalizedString("Pod suspended reminder", comment: "Description for pod suspended reminder alert")
+        // slot6SuspendTimeExpired
         case .suspendTimeExpired:
-            alertName = LocalizedString("Suspend time expired", comment: "Description for suspend time expired")
+            alertName = LocalizedString("Suspend time expired", comment: "Description for suspend time expired alert")
+        // slot7Expired
+        case .waitingForPairingReminder:
+            alertName = LocalizedString("Waiting for pairing reminder", comment: "Description waiting for pairing reminder alert")
+        case .finishSetupReminder:
+            alertName = LocalizedString("Finish setup reminder", comment: "Description for finish setup reminder alert")
+        case .expired:
+            alertName = LocalizedString("Pod expired", comment: "Description for pod expired alert")
         }
         if self.configuration.active == false {
             alertName += LocalizedString(" (inactive)", comment: "Description for an inactive alert modifier")
@@ -118,71 +174,126 @@ public enum PodAlert: CustomStringConvertible, RawRepresentable, Equatable {
 
     public var configuration: AlertConfiguration {
         switch self {
-        case .waitingForPairingReminder:
-            return AlertConfiguration(alertType: .slot7, duration: .minutes(110), trigger: .timeUntilAlert(.minutes(10)), beepRepeat: .every5Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
-        case .finishSetupReminder:
-            return AlertConfiguration(alertType: .slot7, duration: .minutes(55), trigger: .timeUntilAlert(.minutes(5)), beepRepeat: .every5Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
-        case .expirationReminder(let alertTime):
-            let active = alertTime != 0 // disable if alertTime is 0
-            return AlertConfiguration(alertType: .slot3, active: active, duration: 0, trigger: .timeUntilAlert(alertTime), beepRepeat: .every1MinuteFor3MinutesAndRepeatEvery15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
-        case .expired(let alarmTime, let duration):
-            let active = alarmTime != 0 // disable if alarmTime is 0
-            return AlertConfiguration(alertType: .slot7, active: active, duration: duration, trigger: .timeUntilAlert(alarmTime), beepRepeat: .every60Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
-        case .shutdownImminent(let alarmTime):
-            let active = alarmTime != 0 // disable if alarmTime is 0
-            return AlertConfiguration(alertType: .slot2, active: active, duration: 0, trigger: .timeUntilAlert(alarmTime), beepRepeat: .every15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
-        case .lowReservoir(let units):
-            let active = units != 0 // disable if units is 0
-            return AlertConfiguration(alertType: .slot4, active: active, duration: 0, trigger: .unitsRemaining(units), beepRepeat: .every1MinuteFor3MinutesAndRepeatEvery60Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
-        case .autoOff(let active, let countdownDuration):
-            return AlertConfiguration(alertType: .slot0, active: active, autoOffModifier: true, duration: .minutes(15), trigger: .timeUntilAlert(countdownDuration), beepRepeat: .every1MinuteFor15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
-        case .podSuspendedReminder(let active, let suspendTime):
-            // A suspendTime of 0 is an untimed suspend
-            let reminderInterval, duration: TimeInterval
-            let trigger: AlertTrigger
-            let beepRepeat: BeepRepeat
-            let beepType: BeepType
+        // slot0AutoOff
+        case .autoOff(let active, _, let countdownDuration, let silent):
+            return AlertConfiguration(alertType: .slot0AutoOff, active: active, duration: .minutes(15), trigger: .timeUntilAlert(countdownDuration), beepRepeat: .every1MinuteFor15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep, silent: silent, autoOffModifier: true)
+
+        // slot1NotUsed
+        case .notUsed:
+            return AlertConfiguration(alertType: .slot1NotUsed, duration: .minutes(55), trigger: .timeUntilAlert(.minutes(5)), beepRepeat: .every5Minutes, beepType: .noBeepNonCancel, silent: false)
+
+        // slot2ShutdownImminent
+        case .shutdownImminent(let offset, let absAlertTime, let silent):
+            let active = absAlertTime != 0 // disable if absAlertTime is 0
+            let triggerTime: TimeInterval
             if active {
-                if suspendTime >= TimeInterval(minutes :30) {
-                    // Use 15-minute pod suspended reminder beeps for longer scheduled suspend times as per PDM.
-                    reminderInterval = TimeInterval(minutes: 15)
-                    beepRepeat = .every15Minutes
-                } else {
-                    // Use 5-minute pod suspended reminder beeps for shorter scheduled suspend times.
-                    reminderInterval = TimeInterval(minutes: 5)
-                    beepRepeat = .every5Minutes
-                }
+                triggerTime = absAlertTime - offset
+            } else {
+                triggerTime = 0
+            }
+            return AlertConfiguration(alertType: .slot2ShutdownImminent, active: active, trigger: .timeUntilAlert(triggerTime), beepRepeat: .every15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep, silent: silent)
+
+        // slot3ExpirationReminder
+        case .expirationReminder(let offset, let absAlertTime, let duration, let silent):
+            let active = absAlertTime != 0 // disable if absAlertTime is 0
+            let triggerTime: TimeInterval
+            if active {
+                triggerTime = absAlertTime - offset
+            } else {
+                triggerTime = 0
+            }
+            return AlertConfiguration(alertType: .slot3ExpirationReminder, active: active, duration: duration, trigger: .timeUntilAlert(triggerTime), beepRepeat: .every1MinuteFor3MinutesAndRepeatEvery15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep, silent: silent)
+
+        // slot4LowReservoir
+        case .lowReservoir(let units, let silent):
+            let active = units != 0 // disable if units is 0
+            return AlertConfiguration(alertType: .slot4LowReservoir, active: active, trigger: .unitsRemaining(units), beepRepeat: .every1MinuteFor3MinutesAndRepeatEvery60Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep, silent: silent)
+
+        // slot5SuspendedReminder
+        // A suspendTime of 0 is an untimed suspend
+        // timePassed will be > 0 for an existing pod suspended reminder changing its silent state
+        case .podSuspendedReminder(let active, _, let suspendTime, let timePassed, let silent):
+            let reminderInterval, duration: TimeInterval
+            var beepRepeat: BeepRepeat
+            let beepType: BeepType
+            let trigger: AlertTrigger
+            var isActive: Bool = active
+
+            if suspendTime == 0 || suspendTime >= TimeInterval(minutes: 30) {
+                // Use 15-minute pod suspended reminder beeps for untimed or longer scheduled suspend times.
+                reminderInterval = TimeInterval(minutes: 15)
+                beepRepeat = .every15Minutes
+            } else {
+                // Use 5-minute pod suspended reminder beeps for shorter scheduled suspend times.
+                reminderInterval = TimeInterval(minutes: 5)
+                beepRepeat = .every5Minutes
+            }
+
+            // Make alert inactive if there isn't enough remaining in suspend time for a reminder beep.
+            let suspendTimeRemaining = suspendTime - timePassed
+            if suspendTime != 0 && suspendTimeRemaining <= reminderInterval {
+                isActive = false
+            }
+
+            if isActive {
+                // Compute the alert trigger time as the interval until the next upcoming reminder interval
+                let triggerTime: TimeInterval = .seconds(reminderInterval - Double((Int(timePassed) % Int(reminderInterval))))
+
                 if suspendTime == 0 {
                     duration = 0 // Untimed suspend, no duration
-                } else if suspendTime > reminderInterval {
-                    duration = suspendTime - reminderInterval // End after suspendTime total time
                 } else {
-                    duration = .minutes(1) // Degenerate case, end ASAP
+                    // duration is from triggerTime to suspend time remaining
+                    duration = suspendTimeRemaining - triggerTime
                 }
-                trigger = .timeUntilAlert(reminderInterval) // Start after reminderInterval has passed
+                trigger = .timeUntilAlert(triggerTime) // time to next reminder interval with the suspend time
                 beepType = .beep
             } else {
+                beepRepeat = .once
                 duration = 0
                 trigger = .timeUntilAlert(.minutes(0))
-                beepRepeat = .once
                 beepType = .noBeepCancel
             }
-            return AlertConfiguration(alertType: .slot5, active: active, duration: duration, trigger: trigger, beepRepeat: beepRepeat, beepType: beepType)
-        case .suspendTimeExpired(let suspendTime):
+            return AlertConfiguration(alertType: .slot5SuspendedReminder, active: isActive, duration: duration, trigger: trigger, beepRepeat: beepRepeat, beepType: beepType, silent: silent)
+
+        // slot6SuspendTimeExpired
+        case .suspendTimeExpired(_, let suspendTime, let silent):
             let active = suspendTime != 0 // disable if suspendTime is 0
             let trigger: AlertTrigger
             let beepRepeat: BeepRepeat
             let beepType: BeepType
             if active {
                 trigger = .timeUntilAlert(suspendTime)
-                beepRepeat = .every1MinuteFor3MinutesAndRepeatEvery15Minutes
+                beepRepeat = suspendTimeExpiredBeepRepeat
                 beepType = .bipBeepBipBeepBipBeepBipBeep
             } else {
                 trigger = .timeUntilAlert(.minutes(0))
                 beepRepeat = .once
                 beepType = .noBeepCancel
             }
-            return AlertConfiguration(alertType: .slot6, active: active, duration: 0, trigger: trigger, beepRepeat: beepRepeat, beepType: beepType)
+            return AlertConfiguration(alertType: .slot6SuspendTimeExpired, active: active, trigger: trigger, beepRepeat: beepRepeat, beepType: beepType, silent: silent)
+
+        // slot7Expired
+        case .waitingForPairingReminder:
+            // After pod is powered up, beep every 10 minutes for up to 2 hours before pairing before failing
+            let totalDuration: TimeInterval = .hours(2)
+            let startOffset: TimeInterval = .minutes(10)
+            return AlertConfiguration(alertType: .slot7Expired, duration: totalDuration - startOffset, trigger: .timeUntilAlert(startOffset), beepRepeat: .every5Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep, silent: false)
+        case .finishSetupReminder:
+            // After pod is paired, beep every 5 minutes for up to 1 hour for pod setup to complete before failing
+            let totalDuration: TimeInterval = .hours(1)
+            let startOffset: TimeInterval = .minutes(5)
+            return AlertConfiguration(alertType: .slot7Expired, duration: totalDuration - startOffset, trigger: .timeUntilAlert(startOffset), beepRepeat: .every5Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep, silent: false)
+        case .expired(let offset, let absAlertTime, let duration, let silent):
+            // Normally used to alert at Pod.nominalPodLife (72 hours) for Pod.expirationAdvisoryWindow (7 hours)
+            // 2 sets of beeps repeating every 60 minutes
+            let active = absAlertTime != 0 // disable if absAlertTime is 0
+            let triggerTime: TimeInterval
+            if active {
+                triggerTime = absAlertTime - offset
+            } else {
+                triggerTime = .minutes(0)
+            }
+            return AlertConfiguration(alertType: .slot7Expired, active: active, duration: duration, trigger: .timeUntilAlert(triggerTime), beepRepeat: .every60Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep, silent: silent)
         }
     }
 
@@ -195,51 +306,92 @@ public enum PodAlert: CustomStringConvertible, RawRepresentable, Equatable {
         }
 
         switch name {
-        case "waitingForPairingReminder":
-            self = .waitingForPairingReminder
-        case "finishSetupReminder":
-            self = .finishSetupReminder
-        case "expirationReminder":
-            guard let alertTime = rawValue["alertTime"] as? Double else {
-                return nil
-            }
-            self = .expirationReminder(TimeInterval(alertTime))
-        case "expired":
-            guard let alarmTime = rawValue["alarmTime"] as? Double,
-                let duration = rawValue["duration"] as? Double else
+        case "autoOff":
+            guard let active = rawValue["active"] as? Bool,
+                let countdownDuration = rawValue["countdownDuration"] as? TimeInterval else
             {
                 return nil
             }
-            self = .expired(alertTime: TimeInterval(alarmTime), duration: TimeInterval(duration))
+            let offset = rawValue["offset"] as? TimeInterval ?? 0
+            let silent = rawValue["silent"] as? Bool ?? false
+            self = .autoOff(active: active, offset: offset, countdownDuration: countdownDuration, silent: silent)
         case "shutdownImminent":
-            guard let alarmTime = rawValue["alarmTime"] as? Double else {
+            guard let alarmTime = rawValue["alarmTime"] as? TimeInterval else {
                 return nil
             }
-            self = .shutdownImminent(alarmTime)
+            let offset = rawValue["offset"] as? TimeInterval ?? 0
+            let offsetToUse, absAlertTime: TimeInterval
+            if offset == 0 {
+                // use default values as no offset value was found
+                absAlertTime = defaultShutdownImminentTime
+                offsetToUse = absAlertTime - alarmTime
+            } else {
+                absAlertTime = offset + alarmTime
+                offsetToUse = offset
+            }
+            let silent = rawValue["silent"] as? Bool ?? false
+            self = .shutdownImminent(offset: offsetToUse, absAlertTime: absAlertTime, silent: silent)
+        case "expirationReminder":
+            guard let alertTime = rawValue["alertTime"] as? TimeInterval else {
+                return nil
+            }
+            let offset = rawValue["offset"] as? TimeInterval ?? 0
+            let offsetToUse, absAlertTime: TimeInterval
+            if offset == 0 {
+                // use default values as no offset value was found
+                absAlertTime = defaultExpirationReminderTime
+                offsetToUse = absAlertTime - alertTime
+            } else {
+                absAlertTime = offset + alertTime
+                offsetToUse = offset
+            }
+            let duration = rawValue["duration"] as? TimeInterval ?? 0
+            let silent = rawValue["silent"] as? Bool ?? false
+            self = .expirationReminder(offset: offsetToUse, absAlertTime: absAlertTime, duration: duration,  silent: silent)
         case "lowReservoir":
             guard let units = rawValue["units"] as? Double else {
                 return nil
             }
-            self = .lowReservoir(units)
-        case "autoOff":
-            guard let active = rawValue["active"] as? Bool,
-                let countdownDuration = rawValue["countdownDuration"] as? Double else
-            {
-                return nil
-            }
-            self = .autoOff(active: active, countdownDuration: TimeInterval(countdownDuration))
+            let silent = rawValue["silent"] as? Bool ?? false
+            self = .lowReservoir(units: units, silent: silent)
         case "podSuspendedReminder":
             guard let active = rawValue["active"] as? Bool,
-                let suspendTime = rawValue["suspendTime"] as? Double else
+                let suspendTime = rawValue["suspendTime"] as? TimeInterval else
             {
                 return nil
             }
-            self = .podSuspendedReminder(active: active, suspendTime: suspendTime)
+            let offset = rawValue["offset"] as? TimeInterval ?? 0
+            let silent = rawValue["silent"] as? Bool ?? false
+            self = .podSuspendedReminder(active: active, offset: offset, suspendTime: suspendTime, silent: silent)
         case "suspendTimeExpired":
             guard let suspendTime = rawValue["suspendTime"] as? Double else {
                 return nil
             }
-            self = .suspendTimeExpired(suspendTime: suspendTime)
+            let offset = rawValue["offset"] as? TimeInterval ?? 0
+            let silent = rawValue["silent"] as? Bool ?? false
+            self = .suspendTimeExpired(offset: offset, suspendTime: suspendTime, silent: silent)
+        case "waitingForPairingReminder":
+            self = .waitingForPairingReminder
+        case "finishSetupReminder":
+            self = .finishSetupReminder
+        case "expired":
+            guard let alarmTime = rawValue["alarmTime"] as? TimeInterval,
+                let duration = rawValue["duration"] as? TimeInterval else
+            {
+                return nil
+            }
+            let offset = rawValue["offset"] as? TimeInterval ?? 0
+            let offsetToUse, absAlertTime: TimeInterval
+            if offset == 0 {
+                // use default values as no offset value was found
+                absAlertTime = defaultExpiredTime
+                offsetToUse = absAlertTime - alarmTime
+            } else {
+                absAlertTime = offset + alarmTime
+                offsetToUse = offset
+            }
+            let silent = rawValue["silent"] as? Bool ?? false
+            self = .expired(offset: offsetToUse, absAlertTime: absAlertTime, duration: duration, silent: silent)
         default:
             return nil
         }
@@ -249,50 +401,65 @@ public enum PodAlert: CustomStringConvertible, RawRepresentable, Equatable {
 
         let name: String = {
             switch self {
-            case .waitingForPairingReminder:
-                return "waitingForPairingReminder"
-            case .finishSetupReminder:
-                return "finishSetupReminder"
-            case .expirationReminder:
-                return "expirationReminder"
-            case .expired:
-                return "expired"
-            case .shutdownImminent:
-                return "shutdownImminent"
-            case .lowReservoir:
-                return "lowReservoir"
             case .autoOff:
                 return "autoOff"
+            case .notUsed:
+                return "notUsed"
+            case .shutdownImminent:
+                return "shutdownImminent"
+            case .expirationReminder:
+                return "expirationReminder"
+            case .lowReservoir:
+                return "lowReservoir"
             case .podSuspendedReminder:
                 return "podSuspendedReminder"
             case .suspendTimeExpired:
                 return "suspendTimeExpired"
+            case .waitingForPairingReminder:
+                return "waitingForPairingReminder"
+            case .finishSetupReminder:
+                return "finishSetupReminder"
+            case .expired:
+                return "expired"
             }
         }()
-
 
         var rawValue: RawValue = [
             "name": name,
         ]
 
         switch self {
-        case .expirationReminder(let alertTime):
-            rawValue["alertTime"] = alertTime
-        case .expired(let alarmTime, let duration):
-            rawValue["alarmTime"] = alarmTime
-            rawValue["duration"] = duration
-        case .shutdownImminent(let alarmTime):
-            rawValue["alarmTime"] = alarmTime
-        case .lowReservoir(let units):
-            rawValue["units"] = units
-        case .autoOff(let active, let countdownDuration):
+        case .autoOff(let active, let offset, let countdownDuration, let silent):
             rawValue["active"] = active
+            rawValue["offset"] = offset
             rawValue["countdownDuration"] = countdownDuration
-        case .podSuspendedReminder(let active, let suspendTime):
+            rawValue["silent"] = silent
+        case .shutdownImminent(let offset, let absAlertTime, let silent):
+            rawValue["offset"] = offset
+            rawValue["alarmTime"] = absAlertTime - offset
+            rawValue["silent"] = silent
+        case .expirationReminder(let offset, let absAlertTime, let duration, let silent):
+            rawValue["offset"] = offset
+            rawValue["alertTime"] = absAlertTime - offset
+            rawValue["duration"] = duration
+            rawValue["silent"] = silent
+        case .lowReservoir(let units, let silent):
+            rawValue["units"] = units
+            rawValue["silent"] = silent
+        case .podSuspendedReminder(let active, let offset, let suspendTime, _, let silent):
             rawValue["active"] = active
+            rawValue["offset"] = offset
             rawValue["suspendTime"] = suspendTime
-        case .suspendTimeExpired(let suspendTime):
+            rawValue["silent"] = silent
+        case .suspendTimeExpired(let offset, let suspendTime, let silent):
+            rawValue["offset"] = offset
             rawValue["suspendTime"] = suspendTime
+            rawValue["silent"] = silent
+        case .expired(let offset, let absAlertTime, let duration, let silent):
+            rawValue["offset"] = offset
+            rawValue["alarmTime"] = absAlertTime - offset
+            rawValue["duration"] = duration
+            rawValue["silent"] = silent
         default:
             break
         }
@@ -302,42 +469,42 @@ public enum PodAlert: CustomStringConvertible, RawRepresentable, Equatable {
 }
 
 public enum AlertSlot: UInt8 {
-    case slot0 = 0x00
-    case slot1 = 0x01
-    case slot2 = 0x02
-    case slot3 = 0x03
-    case slot4 = 0x04
-    case slot5 = 0x05
-    case slot6 = 0x06
-    case slot7 = 0x07
+    case slot0AutoOff = 0x00
+    case slot1NotUsed = 0x01
+    case slot2ShutdownImminent = 0x02
+    case slot3ExpirationReminder = 0x03
+    case slot4LowReservoir = 0x04
+    case slot5SuspendedReminder = 0x05
+    case slot6SuspendTimeExpired = 0x06
+    case slot7Expired = 0x07
 
     public var bitMaskValue: UInt8 {
         return 1<<rawValue
     }
 
     public typealias AllCases = [AlertSlot]
-    
+
     static var allCases: AllCases {
         return (0..<8).map { AlertSlot(rawValue: $0)! }
     }
 }
 
 public struct AlertSet: RawRepresentable, Collection, CustomStringConvertible, Equatable {
-    
+
     public typealias RawValue = UInt8
     public typealias Index = Int
-    
+
     public let startIndex: Int
     public let endIndex: Int
-    
+
     private let elements: [AlertSlot]
-    
+
     public static let none = AlertSet(rawValue: 0)
-    
+
     public var rawValue: UInt8 {
         return elements.reduce(0) { $0 | $1.bitMaskValue }
     }
-    
+
     public init(slots: [AlertSlot]) {
         self.elements = slots
         self.startIndex = 0
@@ -351,11 +518,11 @@ public struct AlertSet: RawRepresentable, Collection, CustomStringConvertible, E
     public subscript(index: Index) -> AlertSlot {
         return elements[index]
     }
-    
+
     public func index(after i: Int) -> Int {
         return i+1
     }
-    
+
     public var description: String {
         if elements.count == 0 {
             return LocalizedString("No alerts", comment: "Pod alert state when no alerts are active")
@@ -374,9 +541,179 @@ public struct AlertSet: RawRepresentable, Collection, CustomStringConvertible, E
 
 // Returns true if there are any active suspend related alerts
 public func hasActiveSuspendAlert(configuredAlerts: [AlertSlot : PodAlert]) -> Bool {
-    // slot5 is for podSuspendedReminder and slot6 is for suspendTimeExpired
-    if configuredAlerts.contains(where: { ($0.key == .slot5 || $0.key == .slot6) && $0.value.configuration.active }) {
+    if configuredAlerts.contains(where: { ($0.key == .slot5SuspendedReminder || $0.key == .slot6SuspendTimeExpired) && $0.value.configuration.active })
+    {
         return true
     }
     return false
+}
+
+// Returns a descriptive string for all the alerts in alertSet
+public func alertSetString(alertSet: AlertSet) -> String {
+
+    if alertSet.isEmpty {
+        // Don't bother displaying any additional info for an inactive alert
+        return String(describing: alertSet)
+    }
+
+    let alertDescription = alertSet.map { (slot) -> String in
+        switch slot {
+        case .slot0AutoOff:
+            return PodAlert.autoOff(active: true, offset: 0, countdownDuration: 0).description
+        case .slot1NotUsed:
+            return PodAlert.notUsed.description
+        case .slot2ShutdownImminent:
+            return PodAlert.shutdownImminent(offset: 0, absAlertTime: defaultShutdownImminentTime).description
+        case .slot3ExpirationReminder:
+            return PodAlert.expirationReminder(offset: 0, absAlertTime: defaultExpirationReminderTime).description
+        case .slot4LowReservoir:
+            return PodAlert.lowReservoir(units: Pod.maximumReservoirReading).description
+        case .slot5SuspendedReminder:
+            return PodAlert.podSuspendedReminder(active: true, offset: 0, suspendTime: .minutes(30)).description
+        case .slot6SuspendTimeExpired:
+            return PodAlert.suspendTimeExpired(offset: 0, suspendTime: .minutes(30)).description
+        case .slot7Expired:
+            return PodAlert.expired(offset: 0, absAlertTime: defaultExpiredTime, duration: Pod.expirationAdvisoryWindow).description
+        }
+    }
+
+    return alertDescription.joined(separator: ", ")
+}
+
+func configuredAlertsString(configuredAlerts: [AlertSlot : PodAlert]) -> String {
+
+    if configuredAlerts.isEmpty {
+        return String(describing: configuredAlerts)
+    }
+
+    let configuredAlertString = configuredAlerts.map { (configuredAlert) -> String in
+
+        let podAlert = configuredAlert.value
+        let description = podAlert.description
+        guard podAlert.configuration.active else {
+            return description
+        }
+
+        switch podAlert {
+        case .shutdownImminent(_, let absAlertTime, _):
+            return String(format: "%@ @ %@", description, absAlertTime.timeIntervalStr)
+        case .expirationReminder(_, let absAlertTime, _, _):
+            return String(format: "%@ @ %@", description, absAlertTime.timeIntervalStr)
+        case .lowReservoir(let unitTrigger, _):
+            return String(format: "%@ @ %dU", description, Int(unitTrigger))
+        case .podSuspendedReminder(_, let offset, let suspendTime, _, _):
+            return String(format: "%@ ending @ %@ after %@", description, (offset + suspendTime).timeIntervalStr, suspendTime.timeIntervalStr)
+        case .suspendTimeExpired(let offset, let suspendTime, _):
+            return String(format: "%@ @ %@ after %@", description, (offset + suspendTime).timeIntervalStr, suspendTime.timeIntervalStr)
+        case .expired(_, let absAlertTime, _, _):
+            return String(format: "%@ @ %@", description, absAlertTime.timeIntervalStr)
+        default:
+            return ""
+        }
+    }
+
+    return configuredAlertString.joined(separator: ", ")
+}
+
+// Returns an array of appropriate PodAlerts with the specified silent value
+// for all the configuredAlerts given all the current pod conditions.
+func regeneratePodAlerts(silent: Bool, configuredAlerts: [AlertSlot: PodAlert], activeAlertSlots: AlertSet, currentPodTime: TimeInterval, currentReservoirLevel: Double) -> [PodAlert] {
+    var podAlerts: [PodAlert] = []
+
+    for alert in configuredAlerts {
+        // Just skip this alert if not previously active
+        guard alert.value.configuration.active else {
+            continue
+        }
+
+        // Map alerts to corresponding appropriate new ones at the current pod time using the specified silent value.
+        switch alert.value {
+
+        case .shutdownImminent(let offset, let alertTime, _):
+            // alertTime is absolute when offset is non-zero, otherwise use  default value
+            var absAlertTime = offset != 0 ? alertTime : defaultShutdownImminentTime
+            if currentPodTime >= absAlertTime {
+                // alert trigger is not in the future, make inactive using a 0 value
+                absAlertTime = 0
+            }
+            // create new shutdownImminent podAlert using the current timeActive and the original absolute alert time
+            podAlerts.append(PodAlert.shutdownImminent(offset: currentPodTime, absAlertTime: absAlertTime, silent: silent))
+
+        case .expirationReminder(let offset, let alertTime, let alertDuration, _):
+            let duration: TimeInterval
+
+            // alertTime is absolute when offset is non-zero, otherwise use default value
+            var absAlertTime = offset != 0 ? alertTime : defaultExpirationReminderTime
+            if currentPodTime >= absAlertTime {
+                // alert trigger is not in the future, make inactive using a 0 value
+                absAlertTime = 0
+                duration = 0
+            } else {
+                duration = alertDuration
+            }
+            // create new expirationReminder podAlert using the current active time and the original absolute alert time and duration
+            podAlerts.append(PodAlert.expirationReminder(offset: currentPodTime, absAlertTime: absAlertTime, duration: duration, silent: silent))
+
+        case .lowReservoir(let unitTrigger, _):
+            let units: Double
+            if currentReservoirLevel > unitTrigger {
+                units = unitTrigger
+            } else {
+                // reservoir is no longer more than the unitTrigger, make inactive using a 0 value
+                units = 0
+            }
+            podAlerts.append(PodAlert.lowReservoir(units: units, silent: silent))
+
+        case .podSuspendedReminder(let active, let offset, let suspendTime, _, _):
+            let timePassed: TimeInterval = min(currentPodTime - offset, .hours(2))
+            // Pass along the computed time passed since alert was originally set so creation routine can
+            // do all the grunt work dealing with varying reminder intervals and time passing scenarios.
+            podAlerts.append(PodAlert.podSuspendedReminder(active: active, offset: offset, suspendTime: suspendTime, timePassed: timePassed, silent: silent))
+
+        case .suspendTimeExpired(let lastOffset, let lastSuspendTime, _):
+            let absAlertTime = lastOffset + lastSuspendTime
+            let suspendTime: TimeInterval
+            if currentPodTime >= absAlertTime {
+                // alert trigger is no longer in the future
+                if activeAlertSlots.contains(where: { $0 == .slot6SuspendTimeExpired } ) {
+                    // The suspendTimeExpired alert has yet been acknowledged,
+                    // set up a suspendTimeExpired alert for the next 15m interval.
+                    // Compute a new suspendTime that is a multiple of 15 minutes
+                    // from lastOffset which is at least one minute in the future.
+                    let newOffsetSuspendTime = ceil((currentPodTime - lastOffset) / .minutes(15)) * .minutes(15)
+                    let newAbsAlertTime = lastOffset + newOffsetSuspendTime
+                    suspendTime = max(newAbsAlertTime - currentPodTime, .minutes(1))
+                } else {
+                    // The suspendTimeExpired alert was already been acknowledged,
+                    // so now make this alert inactive by using a 0 suspendTime.
+                    suspendTime = 0
+                }
+            } else {
+                // recompute a new suspendTime based on the current pod time
+                suspendTime = absAlertTime - currentPodTime
+                print("setting new suspendTimeExpired suspendTime of \(suspendTime) with currentPodTime\(currentPodTime) and absAlertTime=\(absAlertTime)")
+            }
+            // create a new suspendTimeExpired PodAlert using the current active time and the computed suspendTime (if any)
+            podAlerts.append(PodAlert.suspendTimeExpired(offset: currentPodTime, suspendTime: suspendTime, silent: silent))
+
+        case .expired(let offset, let alertTime, let alertDuration, _):
+            let duration: TimeInterval
+
+            // alertTime is absolute when offset is non-zero, otherwise use default value
+            var absAlertTime = offset != 0 ? alertTime : defaultExpiredTime
+            if currentPodTime >= absAlertTime {
+                // alert trigger is not in the future, make inactive using a 0 value
+                absAlertTime = 0
+                duration = 0
+            } else {
+                duration = alertDuration
+            }
+            // create new expired podAlert using the current active time and the original absolute alert time and duration
+            podAlerts.append(PodAlert.expired(offset: currentPodTime, absAlertTime: absAlertTime, duration: duration, silent: silent))
+
+        default:
+            break
+        }
+    }
+    return podAlerts
 }

--- a/OmniBLE/OmnipodCommon/CRC16.swift
+++ b/OmniBLE/OmnipodCommon/CRC16.swift
@@ -4,7 +4,7 @@
 //
 //  From OmniKit/MessageTransport/CRC16.swift
 //  Created by Pete Schwamb on 10/14/17.
-//  Copyright © 2017 Pete Schwambs. All rights reserved.
+//  Copyright © 2017 Pete Schwamb. All rights reserved.
 //
 
 import Foundation

--- a/OmniBLE/OmnipodCommon/MessageBlocks/ConfigureAlertsCommand.swift
+++ b/OmniBLE/OmnipodCommon/MessageBlocks/ConfigureAlertsCommand.swift
@@ -22,7 +22,9 @@ public struct ConfigureAlertsCommand : NonceResyncableMessageBlock {
             UInt8(4 + configurations.count * AlertConfiguration.length),
             ])
         data.appendBigEndian(nonce)
-        for config in configurations {
+        // Sorting the alerts not required, but it can be helpful for log analysis
+        let sorted = configurations.sorted { $0.slot.rawValue < $1.slot.rawValue }
+        for config in sorted {
             data.append(contentsOf: config.data)
         }
         return data
@@ -93,6 +95,7 @@ extension AlertConfiguration {
         }
         self.beepType = beepType
 
+        self.silent = (beepType == .noBeepNonCancel)
     }
 
     public var data: Data {
@@ -127,7 +130,8 @@ extension AlertConfiguration {
             data.appendBigEndian(minutes)
         }
         data.append(beepRepeat.rawValue)
-        data.append(beepType.rawValue)
+        let beepTypeToSet: BeepType = silent ? .noBeepNonCancel : beepType
+        data.append(beepTypeToSet.rawValue)
 
         return data
     }

--- a/OmniBLE/OmnipodCommon/PumpManagerAlert.swift
+++ b/OmniBLE/OmnipodCommon/PumpManagerAlert.swift
@@ -1,5 +1,5 @@
 //
-//  PodAlert.swift
+//  PumpManagerAlert.swift
 //  OmniBLE
 //
 //  Created by Pete Schwamb on 7/9/20.
@@ -11,7 +11,6 @@ import LoopKit
 import HealthKit
 
 public enum PumpManagerAlert: Hashable {
-    case multiCommand(triggeringSlot: AlertSlot?)
     case podExpireImminent(triggeringSlot: AlertSlot?)
     case userPodExpiration(triggeringSlot: AlertSlot?, scheduledExpirationReminderOffset: TimeInterval)
     case lowReservoir(triggeringSlot: AlertSlot?, lowReservoirReminderValue: Double)
@@ -19,12 +18,13 @@ public enum PumpManagerAlert: Hashable {
     case suspendEnded(triggeringSlot: AlertSlot?)
     case podExpiring(triggeringSlot: AlertSlot?)
     case finishSetupReminder(triggeringSlot: AlertSlot?)
+    case unexpectedAlert(triggeringSlot: AlertSlot?)
     case timeOffsetChangeDetected
-    
+
     var isRepeating: Bool {
         return repeatInterval != nil
     }
-    
+
     var repeatInterval: TimeInterval? {
         switch self {
         case .suspendEnded:
@@ -33,11 +33,9 @@ public enum PumpManagerAlert: Hashable {
             return nil
         }
     }
-        
+
     var contentTitle: String {
         switch self {
-        case .multiCommand:
-            return LocalizedString("Multiple Command Alert", comment: "Alert content title for multiCommand pod alert")
         case .userPodExpiration:
             return LocalizedString("Pod Expiration Reminder", comment: "Alert content title for userPodExpiration pod alert")
         case .podExpiring:
@@ -52,15 +50,15 @@ public enum PumpManagerAlert: Hashable {
             return LocalizedString("Resume Insulin", comment: "Alert content title for suspendEnded pod alert")
         case .finishSetupReminder:
             return LocalizedString("Pod Pairing Incomplete", comment: "Alert content title for finishSetupReminder pod alert")
+        case .unexpectedAlert:
+            return LocalizedString("Unexpected Alert", comment: "Alert content title for unexpected pod alert")
         case .timeOffsetChangeDetected:
             return LocalizedString("Time Change Detected", comment: "Alert content title for timeOffsetChangeDetected pod alert")
         }
     }
-    
+
     var contentBody: String {
         switch self {
-        case .multiCommand:
-            return LocalizedString("Multiple Command Alert", comment: "Alert content body for multiCommand pod alert")
         case .userPodExpiration(_, let offset):
             let formatter = DateComponentsFormatter()
             formatter.allowedUnits = [.hour]
@@ -81,15 +79,16 @@ public enum PumpManagerAlert: Hashable {
             return LocalizedString("The insulin suspension period has ended.\n\nYou can resume delivery from the banner on the home screen or from your pump settings screen. You will be reminded again in 15 minutes.", comment: "Alert content body for suspendEnded pod alert")
         case .finishSetupReminder:
             return LocalizedString("Please finish pairing your pod.", comment: "Alert content body for finishSetupReminder pod alert")
+        case .unexpectedAlert(let triggeringSlot):
+            let slotNumberString = triggeringSlot != nil ? String(describing: triggeringSlot!.rawValue) : "?"
+            return String(format: LocalizedString("Unexpected Pod Alert #%1@!", comment: "Alert content body for unexpected pod alert (1: slotNumberString)"), slotNumberString)
         case .timeOffsetChangeDetected:
             return LocalizedString("The time on your pump is different from the current time. You can review the pump time and and sync to current time in settings.", comment: "Alert content body for timeOffsetChangeDetected pod alert")
         }
     }
-    
+
     var triggeringSlot: AlertSlot? {
         switch self {
-        case .multiCommand(let slot):
-            return slot
         case .userPodExpiration(let slot, _):
             return slot
         case .podExpiring(let slot):
@@ -104,17 +103,19 @@ public enum PumpManagerAlert: Hashable {
             return slot
         case .finishSetupReminder(let slot):
             return slot
+        case .unexpectedAlert(let slot):
+            return slot
         case .timeOffsetChangeDetected:
             return nil
         }
     }
-    
+
     // Override background (UserNotification) content
-    
+
     var backgroundContentTitle: String {
         return contentTitle
     }
-    
+
     var backgroundContentBody: String {
         switch self {
         case .suspendEnded:
@@ -124,23 +125,21 @@ public enum PumpManagerAlert: Hashable {
         }
     }
 
-    
+
     var actionButtonLabel: String {
         return LocalizedString("Ok", comment: "Action button default text for PodAlerts")
     }
-    
+
     var foregroundContent: Alert.Content {
         return Alert.Content(title: contentTitle, body: contentBody, acknowledgeActionButtonLabel: actionButtonLabel)
     }
-    
+
     var backgroundContent: Alert.Content {
         return Alert.Content(title: backgroundContentTitle, body: backgroundContentBody, acknowledgeActionButtonLabel: actionButtonLabel)
     }
-    
+
     var alertIdentifier: String {
         switch self {
-        case .multiCommand:
-            return "multiCommand"
         case .userPodExpiration:
             return "userPodExpiration"
         case .podExpiring:
@@ -153,38 +152,38 @@ public enum PumpManagerAlert: Hashable {
             return "suspendInProgress"
         case .suspendEnded:
             return "suspendEnded"
-        case .timeOffsetChangeDetected:
-            return "timeOffsetChangeDetected"
         case .finishSetupReminder:
             return "finishSetupReminder"
+        case .unexpectedAlert:
+            return "unexpectedAlert"
+        case .timeOffsetChangeDetected:
+            return "timeOffsetChangeDetected"
         }
     }
-        
+
     var repeatingAlertIdentifier: String {
         return alertIdentifier + "-repeating"
     }
 }
 
 extension PumpManagerAlert: RawRepresentable {
-    
+
     public typealias RawValue = [String: Any]
-    
+
     public init?(rawValue: RawValue) {
         guard let identifier = rawValue["identifier"] as? String else {
             return nil
         }
-        
+
         let slot: AlertSlot?
-        
+
         if let rawSlot = rawValue["slot"] as? AlertSlot.RawValue {
             slot = AlertSlot(rawValue: rawSlot)
         } else {
             slot = nil
         }
-        
+
         switch identifier {
-        case "multiCommand":
-            self = .multiCommand(triggeringSlot: slot)
         case "userPodExpiration":
             guard let offset = rawValue["offset"] as? TimeInterval, offset > 0 else {
                 return nil
@@ -203,6 +202,8 @@ extension PumpManagerAlert: RawRepresentable {
             self = .suspendInProgress(triggeringSlot: slot)
         case "suspendEnded":
             self = .suspendEnded(triggeringSlot: slot)
+        case "unexpectedAlert":
+            self = .unexpectedAlert(triggeringSlot: slot)
         case "timeOffsetChangeDetected":
             self = .timeOffsetChangeDetected
         default:
@@ -214,9 +215,9 @@ extension PumpManagerAlert: RawRepresentable {
         var rawValue: RawValue = [
             "identifier": alertIdentifier
         ]
-        
+
         rawValue["slot"] = triggeringSlot?.rawValue
-        
+
         switch self {
         case .lowReservoir(_, lowReservoirReminderValue: let value):
             rawValue["value"] = value
@@ -225,18 +226,7 @@ extension PumpManagerAlert: RawRepresentable {
         default:
             break
         }
-        
-        return rawValue
-    }
-}
 
-extension PodAlert {
-    var isIgnored: Bool {
-        switch self {
-        case .podSuspendedReminder, .finishSetupReminder:
-            return true
-        default:
-            return false
-        }
+        return rawValue
     }
 }

--- a/OmniBLE/OmnipodCommon/SilencePodPreference.swift
+++ b/OmniBLE/OmnipodCommon/SilencePodPreference.swift
@@ -1,0 +1,32 @@
+//
+//  SilencePodPreference.swift
+//  OmniBLE
+//
+//  Created by Joe Moran on 8/30/23.
+//  Copyright © 2023 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+
+public enum SilencePodPreference: Int, CaseIterable {
+    case disabled
+    case enabled
+
+    var title: String {
+        switch self {
+        case .disabled:
+            return LocalizedString("Disabled", comment: "Title string for SilencePodPreference.disabled")
+        case .enabled:
+            return LocalizedString("Silenced", comment: "Title string for SilencePodPreference.enabled")
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .disabled:
+            return LocalizedString("Normal operation mode where audible Pod beeps are used for all Pod alerts and when confidence reminders are enabled.", comment: "Description for SilencePodPreference.disabled")
+        case .enabled:
+            return LocalizedString("All Pod alerts use no beeps and confirmation reminder beeps are suppressed. The Pod will only beep for fatal Pod faults and when playing test beeps.\n\n⚠️Warning - Whenever the Pod is silenced it must be kept within Bluetooth range of this device to receive notifications for Pod alerts.", comment: "Description for SilencePodPreference.enabled")
+        }
+    }
+}

--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -135,14 +135,6 @@ public class OmniBLEPumpManager: DeviceManager {
         return setStateWithResult(changes)
     }
 
-    @discardableResult
-    private func mutateState(_ changes: (_ state: inout OmniBLEPumpManagerState) -> Void) -> OmniBLEPumpManagerState {
-        return setStateWithResult({ (state) -> OmniBLEPumpManagerState in
-            changes(&state)
-            return state
-        })
-    }
-
     // Status can change even when state does not, because some status changes
     // purely based on time. This provides a mechanism to evaluate status changes
     // as time progresses and trigger status updates to clients.
@@ -427,10 +419,22 @@ extension OmniBLEPumpManager {
         return false
     }
 
+
+    private var podTime: TimeInterval {
+        get {
+            guard let podState = state.podState else {
+                return 0
+            }
+            let elapsed = -(podState.podTimeUpdated?.timeIntervalSinceNow ?? 0)
+            let podActiveTime = podState.podTime + elapsed
+            return podActiveTime
+        }
+    }
+
     // Returns a suitable beep command MessageBlock based the current beep preferences and
     // whether there is an unfinializedDose for a manual temp basal &/or a manual bolus.
     private func beepMessageBlock(beepType: BeepType) -> MessageBlock? {
-        guard self.beepPreference.shouldBeepForManualCommand else {
+        guard self.beepPreference.shouldBeepForManualCommand && !self.silencePod else {
             return nil
         }
 
@@ -513,6 +517,13 @@ extension OmniBLEPumpManager {
         }
     }
 
+    // Thread-safe
+    public var silencePod: Bool {
+        get {
+            return state.silencePod
+        }
+    }
+
     // From last status response
     public var reservoirLevel: ReservoirLevel? {
         return state.reservoirLevel
@@ -534,7 +545,7 @@ extension OmniBLEPumpManager {
 
     public var defaultExpirationReminderOffset: TimeInterval {
         set {
-            mutateState { (state) in
+            setState { (state) in
                 state.defaultExpirationReminderOffset = newValue
             }
         }
@@ -545,7 +556,7 @@ extension OmniBLEPumpManager {
 
     public var lowReservoirReminderValue: Double {
         set {
-            mutateState { (state) in
+            setState { (state) in
                 state.lowReservoirReminderValue = newValue
             }
         }
@@ -556,7 +567,7 @@ extension OmniBLEPumpManager {
 
     public var podAttachmentConfirmed: Bool {
         set {
-            mutateState { (state) in
+            setState { (state) in
                 state.podAttachmentConfirmed = newValue
             }
         }
@@ -567,7 +578,7 @@ extension OmniBLEPumpManager {
 
     public var initialConfigurationCompleted: Bool {
         set {
-            mutateState { (state) in
+            setState { (state) in
                 state.initialConfigurationCompleted = newValue
             }
         }
@@ -977,15 +988,13 @@ extension OmniBLEPumpManager {
                         }
                     }
 
-                    let expiration = self.podExpiresAt ?? Date().addingTimeInterval(Pod.nominalPodLife)
-                    let timeUntilExpirationReminder = expiration.addingTimeInterval(-self.state.defaultExpirationReminderOffset).timeIntervalSince(self.dateGenerator())
-
+                    let expirationReminderTime = Pod.nominalPodLife - self.state.defaultExpirationReminderOffset
                     let alerts: [PodAlert] = [
-                        .expirationReminder(self.state.defaultExpirationReminderOffset > 0 ? timeUntilExpirationReminder : 0),
-                        .lowReservoir(self.state.lowReservoirReminderValue)
+                        .expirationReminder(offset: self.podTime, absAlertTime: self.state.defaultExpirationReminderOffset > 0 ? expirationReminderTime : 0, silent: self.state.silencePod),
+                        .lowReservoir(units: self.lowReservoirReminderValue, silent: self.state.silencePod)
                     ]
 
-                    let finishWait = try session.insertCannula(optionalAlerts: alerts)
+                    let finishWait = try session.insertCannula(optionalAlerts: alerts, silent: self.state.silencePod)
                     completion(.success(finishWait))
                 } catch let error {
                     completion(.failure(.communication(error)))
@@ -1073,13 +1082,41 @@ extension OmniBLEPumpManager {
         }
     }
 
-    public func acknowledgePodAlerts(_ alertsToAcknowledge: AlertSet, completion: @escaping (_ alerts: [AlertSlot: PodAlert]?) -> Void) {
+    public func getDetailedStatus(completion: ((_ result: PumpManagerResult<DetailedStatus>) -> Void)? = nil) {
+
+        // use hasSetupPod here instead of hasActivePod as DetailedStatus can be read with a faulted Pod
+        guard self.hasSetupPod else {
+            completion?(.failure(PumpManagerError.configuration(OmniBLEPumpManagerError.noPodPaired)))
+            return
+        }
+
+        podComms.runSession(withName: "Get detailed status") { (result) in
+            do {
+                switch result {
+                case .success(let session):
+                    let beepBlock = self.beepMessageBlock(beepType: .bipBip)
+                    let detailedStatus = try session.getDetailedStatus(beepBlock: beepBlock)
+                    session.dosesForStorage({ (doses) -> Bool in
+                        self.store(doses: doses, in: session)
+                    })
+                    completion?(.success(detailedStatus))
+                case .failure(let error):
+                    throw error
+                }
+            } catch let error {
+                completion?(.failure(.communication(error as? LocalizedError)))
+                self.log.error("Failed to fetch detailed status: %{public}@", String(describing: error))
+            }
+        }
+    }
+
+    public func acknowledgePodAlerts(_ alertsToAcknowledge: AlertSet, completion: @escaping (_ alerts: AlertSet?) -> Void) {
         guard self.hasActivePod else {
             completion(nil)
             return
         }
 
-        self.podComms.runSession(withName: "Acknowledge Alarms") { (result) in
+        self.podComms.runSession(withName: "Acknowledge Alerts") { (result) in
             let session: PodCommsSession
             switch result {
             case .success(let s):
@@ -1128,7 +1165,7 @@ extension OmniBLEPumpManager {
             switch result {
             case .success(let session):
                 do {
-                    let beep = self.beepPreference.shouldBeepForManualCommand
+                    let beep = self.silencePod ? false : self.beepPreference.shouldBeepForManualCommand
                     let _ = try session.setTime(timeZone: timeZone, basalSchedule: self.state.basalSchedule, date: Date(), acknowledgementBeep: beep)
                     self.clearSuspendReminder()
                     self.setState { (state) in
@@ -1191,7 +1228,7 @@ extension OmniBLEPumpManager {
                     case .success:
                         break
                     }
-                    let beep = self.beepPreference.shouldBeepForManualCommand
+                    let beep = self.silencePod ? false : self.beepPreference.shouldBeepForManualCommand
                     let _ = try session.setBasalSchedule(schedule: schedule, scheduleOffset: scheduleOffset, acknowledgementBeep: beep)
                     self.clearSuspendReminder()
 
@@ -1253,12 +1290,12 @@ extension OmniBLEPumpManager {
         self.podComms.runSession(withName: "Play Test Beeps") { (result) in
             switch result {
             case .success(let session):
-                // preserve Pod completion beep state for any unfinalized manual insulin delivery
-                let beep = self.beepPreference.shouldBeepForManualCommand
+                // preserve the pod's completion beep state which gets reset playing beeps
+                let enabled: Bool = self.silencePod ? false : self.beepPreference.shouldBeepForManualCommand
                 let result = session.beepConfig(
                     beepType: .bipBeepBipBeepBipBeepBipBeep,
-                    tempBasalCompletionBeep: beep && self.hasUnfinalizedManualTempBasal,
-                    bolusCompletionBeep: beep && self.hasUnfinalizedManualBolus
+                    tempBasalCompletionBeep: enabled && self.hasUnfinalizedManualTempBasal,
+                    bolusCompletionBeep: enabled && self.hasUnfinalizedManualBolus
                 )
 
                 switch result {
@@ -1310,17 +1347,111 @@ extension OmniBLEPumpManager {
         }
     }
 
+    public func readPulseLogPlus(completion: @escaping (Result<String, Error>) -> Void) {
+        // use hasSetupPod here instead of hasActivePod as PodInfo can be read with a faulted Pod
+        guard self.hasSetupPod else {
+            completion(.failure(OmniBLEPumpManagerError.noPodPaired))
+            return
+        }
+        guard state.podState?.isFaulted == true || state.podState?.unfinalizedBolus?.scheduledCertainty == .uncertain || state.podState?.unfinalizedBolus?.isFinished() != false else
+        {
+            self.log.info("Skipping Read Pulse Log Plus due to bolus still in progress.")
+            completion(.failure(PodCommsError.unfinalizedBolus))
+            return
+        }
+
+        podComms.runSession(withName: "Read Pulse Log Plus") { (result) in
+            do {
+                switch result {
+                case .success(let session):
+                    let beepBlock = self.beepMessageBlock(beepType: .bipBeeeeep)
+                    let podInfoResponse = try session.readPodInfo(podInfoResponseSubType: .pulseLogPlus, beepBlock: beepBlock)
+                    guard let podInfoPulseLogPlus = podInfoResponse.podInfo as? PodInfoPulseLogPlus else {
+                        self.log.error("Unable to decode Pulse Log Plus: %s", String(describing: podInfoResponse))
+                        throw PodCommsError.unexpectedResponse(response: .podInfoResponse)
+                    }
+                    let str = pulseLogPlusString(podInfoPulseLogPlus: podInfoPulseLogPlus)
+                    completion(.success(str))
+                case .failure(let error):
+                    throw error
+                }
+            } catch let error {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    public func readActivationTime(completion: @escaping (Result<String, Error>) -> Void) {
+        // use hasSetupPod here instead of hasActivePod as PodInfo can be read with a faulted Pod
+        guard self.hasSetupPod else {
+            completion(.failure(OmniBLEPumpManagerError.noPodPaired))
+            return
+        }
+
+        podComms.runSession(withName: "Read Activation Time") { (result) in
+            do {
+                switch result {
+                case .success(let session):
+                    let beepBlock = self.beepMessageBlock(beepType: .beepBeep)
+                    let podInfoResponse = try session.readPodInfo(podInfoResponseSubType: .activationTime, beepBlock: beepBlock)
+                    guard let podInfoActivationTime = podInfoResponse.podInfo as? PodInfoActivationTime else {
+                        self.log.error("Unable to decode Activation Time: %s", String(describing: podInfoResponse))
+                        throw PodCommsError.unexpectedResponse(response: .podInfoResponse)
+                    }
+                    let str = activationTimeString(podInfoActivationTime: podInfoActivationTime)
+                    completion(.success(str))
+                case .failure(let error):
+                    throw error
+                }
+            } catch let error {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    public func readTriggeredAlerts(completion: @escaping (Result<String, Error>) -> Void) {
+        // use hasSetupPod here instead of hasActivePod as PodInfo can be read with a faulted Pod
+        guard self.hasSetupPod else {
+            completion(.failure(OmniBLEPumpManagerError.noPodPaired))
+            return
+        }
+
+        podComms.runSession(withName: "Read Triggered Alerts") { (result) in
+            do {
+                switch result {
+                case .success(let session):
+                    let beepBlock = self.beepMessageBlock(beepType: .beepBeep)
+                    let podInfoResponse = try session.readPodInfo(podInfoResponseSubType: .triggeredAlerts, beepBlock: beepBlock)
+                    guard let podInfoTriggeredAlerts = podInfoResponse.podInfo as? PodInfoTriggeredAlerts else {
+                        self.log.error("Unable to decode Read Triggered Alerts: %s", String(describing: podInfoResponse))
+                        throw PodCommsError.unexpectedResponse(response: .podInfoResponse)
+                    }
+                    let str = triggeredAlertsString(podInfoTriggeredAlerts: podInfoTriggeredAlerts)
+                    completion(.success(str))
+                case .failure(let error):
+                    throw error
+                }
+            } catch let error {
+                completion(.failure(error))
+            }
+        }
+    }
+
     public func setConfirmationBeeps(newPreference: BeepPreference, completion: @escaping (OmniBLEPumpManagerError?) -> Void) {
-        self.log.default("Set Confirmation Beeps to %s", String(describing: newPreference))
-        guard self.hasActivePod else {
+
+        // If there isn't an active pod or the pod is currently silenced,
+        // just need to update the internal state without any pod commands.
+        let name = String(format: "Set Beep Preference to %@", String(describing: newPreference))
+        if !self.hasActivePod || self.silencePod {
+            self.log.default("%{public}@ for internal state only", name)
             self.setState { state in
-                state.confirmationBeeps = newPreference // set here to allow changes on a faulted Pod
+                state.confirmationBeeps = newPreference
             }
             completion(nil)
             return
         }
 
-        self.podComms.runSession(withName: "Set Confirmation Beeps Preference") { (result) in
+        self.podComms.runSession(withName: name) { (result) in
             switch result {
             case .success(let session):
                 // enable/disable Pod completion beep state for any unfinalized manual insulin delivery
@@ -1342,6 +1473,75 @@ extension OmniBLEPumpManager {
                     completion(.communication(error))
                 }
             case .failure(let error):
+                completion(.communication(error))
+            }
+        }
+    }
+
+    // Reconfigures all active alerts in pod to be silent or not as well as sets/clears the
+    // self.silencePod state variable which silences all confirmation beeping when enabled.
+    public func setSilencePod(silencePod: Bool, completion: @escaping (OmniBLEPumpManagerError?) -> Void) {
+
+        let name = String(format: "%@ Pod", silencePod ? "Silence" : "Unsilence")
+        // allow Silence Pod changes without an active Pod
+        guard self.hasActivePod else {
+            self.log.default("%{public}@", name)
+            self.setState { state in
+                state.silencePod = silencePod
+            }
+            completion(nil)
+            return
+        }
+
+        self.podComms.runSession(withName: name) { (result) in
+
+            let session: PodCommsSession
+            switch result {
+            case .success(let s):
+                session = s
+            case .failure(let error):
+                completion(.communication(error))
+                return
+            }
+
+            guard let configuredAlerts = self.state.podState?.configuredAlerts,
+                  let activeAlertSlots = self.state.podState?.activeAlertSlots,
+                  let reservoirLevel = self.state.podState?.lastInsulinMeasurements?.reservoirLevel?.rawValue else
+            {
+                self.log.error("Missing podState") // should never happen
+                completion(OmniBLEPumpManagerError.noPodPaired)
+                return
+            }
+
+            let beepBlock: MessageBlock?
+            if !self.beepPreference.shouldBeepForManualCommand {
+                // No enabled completion beeps to worry about for any in-progress manual delivery
+                beepBlock = nil
+            } else if silencePod {
+                // Disable completion beeps for any in-progress manual delivery w/o beeping
+                beepBlock = BeepConfigCommand(beepType: .noBeepNonCancel)
+            } else {
+                // Emit a confirmation beep and enable completion beeps for any in-progress manual delivery
+                beepBlock = BeepConfigCommand(
+                    beepType: .bipBip,
+                    tempBasalCompletionBeep: self.hasUnfinalizedManualTempBasal,
+                    bolusCompletionBeep: self.hasUnfinalizedManualBolus
+                )
+            }
+
+            let podAlerts = regeneratePodAlerts(silent: silencePod, configuredAlerts: configuredAlerts, activeAlertSlots: activeAlertSlots, currentPodTime: self.podTime, currentReservoirLevel: reservoirLevel)
+            do {
+                // Since non-responsive pod comms are currently only resolved for insulin related commands,
+                // it's possible that a response from a previous successful pod alert configuration can be lost
+                // and thus the alert won't get reset here when reconfiguring pod alerts with a new silence pod state.
+                let acknowledgeAll = true   // protect against lost alert configuration response related issues
+                try session.configureAlerts(podAlerts, acknowledgeAll: acknowledgeAll, beepBlock: beepBlock)
+                self.setState { (state) in
+                    state.silencePod = silencePod
+                }
+                completion(nil)
+            } catch {
+                self.log.error("Configure alerts %{public}@ failed: %{public}@", String(describing: podAlerts), String(describing: error))
                 completion(.communication(error))
             }
         }
@@ -1509,7 +1709,7 @@ extension OmniBLEPumpManager: PumpManager {
 
             // Use a beepBlock for the confirmation beep to avoid getting 3 beeps using cancel command beeps!
             let beepBlock = self.beepMessageBlock(beepType: .beeeeeep)
-            let result = session.suspendDelivery(suspendReminder: suspendReminder, beepBlock: beepBlock)
+            let result = session.suspendDelivery(suspendReminder: suspendReminder, silent: self.silencePod, beepBlock: beepBlock)
             switch result {
             case .certainFailure(let error):
                 self.log.error("Failed to suspend: %{public}@", String(describing: error))
@@ -1555,7 +1755,7 @@ extension OmniBLEPumpManager: PumpManager {
 
             do {
                 let scheduleOffset = self.state.timeZone.scheduleOffset(forDate: Date())
-                let beep = self.beepPreference.shouldBeepForManualCommand
+                let beep = self.silencePod ? false : self.beepPreference.shouldBeepForManualCommand
                 let _ = try session.resumeBasal(schedule: self.state.basalSchedule, scheduleOffset: scheduleOffset, acknowledgementBeep: beep)
                 self.clearSuspendReminder()
                 session.dosesForStorage() { (doses) -> Bool in
@@ -1620,8 +1820,14 @@ extension OmniBLEPumpManager: PumpManager {
         // Round to nearest supported volume
         let enactUnits = roundToSupportedBolusVolume(units: units)
 
-        let acknowledgementBeep = self.beepPreference.shouldBeepForCommand(automatic: activationType.isAutomatic)
-        let completionBeep = beepPreference.shouldBeepForManualCommand && !activationType.isAutomatic
+        let acknowledgementBeep, completionBeep: Bool
+        if self.silencePod {
+            acknowledgementBeep = false
+            completionBeep = false
+        } else {
+            acknowledgementBeep = self.beepPreference.shouldBeepForCommand(automatic: activationType.isAutomatic)
+            completionBeep = beepPreference.shouldBeepForManualCommand && !activationType.isAutomatic
+        }
 
         self.podComms.runSession(withName: "Bolus") { (result) in
             let session: PodCommsSession
@@ -1716,8 +1922,8 @@ extension OmniBLEPumpManager: PumpManager {
                 }
 
                 // when cancelling a bolus use the built-in type 6 beeeeeep to match PDM if confirmation beeps are enabled
-                let beeptype: BeepType = self.beepPreference.shouldBeepForManualCommand ? .beeeeeep : .noBeepCancel
-                let result = session.cancelDelivery(deliveryType: .bolus, beepType: beeptype)
+                let beepType: BeepType = self.beepPreference.shouldBeepForManualCommand && !self.silencePod ? .beeeeeep : .noBeepCancel
+                let result = session.cancelDelivery(deliveryType: .bolus, beepType: beepType)
                 switch result {
                 case .certainFailure(let error):
                     throw error
@@ -1763,8 +1969,14 @@ extension OmniBLEPumpManager: PumpManager {
         // Round to nearest supported rate
         let rate = roundToSupportedBasalRate(unitsPerHour: unitsPerHour)
 
-        let acknowledgementBeep = beepPreference.shouldBeepForCommand(automatic: automatic)
-        let completionBeep = beepPreference.shouldBeepForManualCommand && !automatic
+        let acknowledgementBeep, completionBeep: Bool
+        if self.silencePod {
+            acknowledgementBeep = false
+            completionBeep = false
+        } else {
+            acknowledgementBeep = beepPreference.shouldBeepForCommand(automatic: automatic)
+            completionBeep = beepPreference.shouldBeepForManualCommand && !automatic
+        }
 
         self.podComms.runSession(withName: "Enact Temp Basal") { (result) in
             self.log.info("Enact temp basal %.03fU/hr for %ds", rate, Int(duration))
@@ -1892,7 +2104,7 @@ extension OmniBLEPumpManager: PumpManager {
     }
 
     public func syncDeliveryLimits(limits deliveryLimits: DeliveryLimits, completion: @escaping (Result<DeliveryLimits, Error>) -> Void) {
-        mutateState { state in
+        setState { state in
             if let rate = deliveryLimits.maximumBasalRate?.doubleValue(for: .internationalUnitsPerHour) {
                 state.maximumTempBasalRate = rate
                 completion(.success(deliveryLimits))
@@ -1937,16 +2149,25 @@ extension OmniBLEPumpManager: PumpManager {
                 return
             }
 
-            var timeUntilReminder : TimeInterval = 0
+            let podTime = self.podTime
+            var expirationReminderPodTime: TimeInterval = 0 // default to expiration reminder alert inactive
+
+            // If the interval before expiration is not a positive value (e.g., it's in the past),
+            // then the pod alert will get the default alert time of 0 making this alert inactive.
             if let intervalBeforeExpiration = intervalBeforeExpiration, intervalBeforeExpiration > 0 {
-                timeUntilReminder = expiresAt.addingTimeInterval(-intervalBeforeExpiration).timeIntervalSince(self.dateGenerator())
+                let timeUntilReminder = expiresAt.addingTimeInterval(-intervalBeforeExpiration).timeIntervalSince(self.dateGenerator())
+                // Only bother to set an expiration reminder pod alert if it is still at least a couple of minutes in the future
+                if timeUntilReminder > .minutes(2) {
+                    expirationReminderPodTime = podTime + timeUntilReminder
+                    self.log.debug("Update Expiration timeUntilReminder=%@, podTime=%@, expirationReminderPodTime=%@", timeUntilReminder.timeIntervalStr, podTime.timeIntervalStr, expirationReminderPodTime.timeIntervalStr)
+                }
             }
 
-            let expirationReminder = PodAlert.expirationReminder(timeUntilReminder)
+            let expirationReminder = PodAlert.expirationReminder(offset: podTime, absAlertTime: expirationReminderPodTime, silent: self.silencePod)
             do {
                 let beepBlock = self.beepMessageBlock(beepType: .beep)
                 try session.configureAlerts([expirationReminder], beepBlock: beepBlock)
-                self.mutateState({ (state) in
+                self.setState({ (state) in
                     state.scheduledExpirationReminderOffset = intervalBeforeExpiration
                 })
                 completion(nil)
@@ -1970,7 +2191,8 @@ extension OmniBLEPumpManager: PumpManager {
             expiration.addingTimeInterval(.hours(Double(i)))
         }
         let now = dateGenerator()
-        return allDates.filter { $0.timeIntervalSince(now) > 0 }
+        // Have a couple minutes of slop to avoid confusion trying to set an expiration reminder too close to now
+        return allDates.filter { $0.timeIntervalSince(now) > .minutes(2) }
     }
 
     public var scheduledExpirationReminder: Date? {
@@ -1983,9 +2205,26 @@ extension OmniBLEPumpManager: PumpManager {
         return expiration.addingTimeInterval(-.hours(round(offset.hours)))
     }
 
+    // Updates the low reservior reminder value both for the current pod (when applicable) and for future pods
     public func updateLowReservoirReminder(_ value: Int, completion: @escaping (OmniBLEPumpManagerError?) -> Void) {
+
+        let supportedValue = min(max(0, Double(value)), Pod.maximumReservoirReading)
+        let setLowReservoirReminderValue = {
+            self.log.default("Set Low Reservoir Reminder to %d U", value)
+            self.lowReservoirReminderValue = supportedValue
+            completion(nil)
+        }
+
         guard self.hasActivePod else {
-            completion(OmniBLEPumpManagerError.noPodPaired)
+            // no active pod, just set the internal state for the next pod
+            setLowReservoirReminderValue()
+            return
+        }
+
+        guard let currentReservoirLevel = self.reservoirLevel?.rawValue, currentReservoirLevel > supportedValue else {
+            // Since the new low reservoir alert level is not below the current reservoir value,
+            // just set the internal state for the next pod to prevent an immediate low reservoir alert.
+            setLowReservoirReminderValue()
             return
         }
 
@@ -2000,13 +2239,11 @@ extension OmniBLEPumpManager: PumpManager {
                 return
             }
 
-            let lowReservoirReminder = PodAlert.lowReservoir(Double(value))
+            let lowReservoirReminder = PodAlert.lowReservoir(units: supportedValue, silent: self.silencePod)
             do {
                 let beepBlock = self.beepMessageBlock(beepType: .beep)
                 try session.configureAlerts([lowReservoirReminder], beepBlock: beepBlock)
-                self.mutateState({ (state) in
-                    state.lowReservoirReminderValue = Double(value)
-                })
+                self.lowReservoirReminderValue = supportedValue
                 completion(nil)
             } catch {
                 completion(.communication(error))
@@ -2031,7 +2268,7 @@ extension OmniBLEPumpManager: PumpManager {
             }
         }
 
-        self.mutateState { (state) in
+        self.setState { (state) in
             state.activeAlerts.insert(alert)
         }
     }
@@ -2047,7 +2284,7 @@ extension OmniBLEPumpManager: PumpManager {
                 delegate?.retractAlert(identifier: repeatingIdentifier)
             }
         }
-        self.mutateState { (state) in
+        self.setState { (state) in
             state.activeAlerts.remove(alert)
         }
     }
@@ -2068,6 +2305,8 @@ extension OmniBLEPumpManager: PumpManager {
                 }
             } else {
                 log.error("Unconfigured alert slot triggered: %{public}@", String(describing: slot))
+                let pumpManagerAlert = PumpManagerAlert.unexpectedAlert(triggeringSlot: slot)
+                issueAlert(alert: pumpManagerAlert)
             }
         }
         for alert in removed {
@@ -2076,34 +2315,24 @@ extension OmniBLEPumpManager: PumpManager {
     }
 
     private func getPumpManagerAlert(for podAlert: PodAlert, slot: AlertSlot) -> PumpManagerAlert? {
-        guard let podState = state.podState, let expiresAt = podState.expiresAt else {
-            preconditionFailure("trying to lookup alert info without podState")
-        }
-
-        guard !podAlert.isIgnored else {
-            return nil
-        }
 
         switch podAlert {
-        case .podSuspendedReminder:
-            return PumpManagerAlert.suspendInProgress(triggeringSlot: slot)
+        case .shutdownImminent:
+            return PumpManagerAlert.podExpireImminent(triggeringSlot: slot)
         case .expirationReminder:
-            guard let offset = state.scheduledExpirationReminderOffset, offset > 0 else {
-                return nil
+            guard let podState = state.podState, let expiresAt = podState.expiresAt else {
+                preconditionFailure("trying to lookup expiresAt")
             }
             let timeToExpiry = TimeInterval(hours: expiresAt.timeIntervalSince(dateGenerator()).hours.rounded())
             return PumpManagerAlert.userPodExpiration(triggeringSlot: slot, scheduledExpirationReminderOffset: timeToExpiry)
-        case .expired:
-            return PumpManagerAlert.podExpiring(triggeringSlot: slot)
-        case .shutdownImminent:
-            return PumpManagerAlert.podExpireImminent(triggeringSlot: slot)
-        case .lowReservoir(let units):
+        case .lowReservoir(let units, _):
             return PumpManagerAlert.lowReservoir(triggeringSlot: slot, lowReservoirReminderValue: units)
-        case .finishSetupReminder, .waitingForPairingReminder:
-            return PumpManagerAlert.finishSetupReminder(triggeringSlot: slot)
         case .suspendTimeExpired:
             return PumpManagerAlert.suspendEnded(triggeringSlot: slot)
+        case .expired:
+            return PumpManagerAlert.podExpiring(triggeringSlot: slot)
         default:
+            // No PumpManagerAlerts are used for any other pod alerts (including suspendInProgress).
             return nil
         }
     }
@@ -2120,7 +2349,7 @@ extension OmniBLEPumpManager: PumpManager {
                         } catch {
                             return
                         }
-                        self.mutateState { state in
+                        self.setState { state in
                             state.activeAlerts.remove(alert)
                             state.alertsWithPendingAcknowledgment.remove(alert)
                         }
@@ -2263,7 +2492,7 @@ extension OmniBLEPumpManager: PodCommsDelegate {
             }
         } else {
             // Resetting podState
-            mutateState { state in
+            setState { state in
                 state.updatePodStateFromPodComms(podState)
             }
         }
@@ -2289,9 +2518,16 @@ extension OmniBLEPumpManager {
         }
 
         for alert in state.activeAlerts {
-            if alert.alertIdentifier == alertIdentifier {
+            if alert.alertIdentifier == alertIdentifier || alert.repeatingAlertIdentifier == alertIdentifier {
                 // If this alert was triggered by the pod find the slot to clear it.
                 if let slot = alert.triggeringSlot {
+                    if case .some(.suspended) = self.state.podState?.suspendState, slot == .slot6SuspendTimeExpired {
+                        // Don't clear this pod alert here with the pod still suspended so that the suspend time expired
+                        // pod alert beeping will continue until the pod is resumed which will then deactivate this alert.
+                        log.default("Skipping acknowledgement of suspend time expired alert with a suspended pod")
+                        completion(nil)
+                        return
+                    }
                     self.podComms.runSession(withName: "Acknowledge Alert") { (result) in
                         switch result {
                         case .success(let session):
@@ -2299,18 +2535,18 @@ extension OmniBLEPumpManager {
                                 let beepBlock = self.beepMessageBlock(beepType: .beep)
                                 let _ = try session.acknowledgeAlerts(alerts: AlertSet(slots: [slot]), beepBlock: beepBlock)
                             } catch {
-                                self.mutateState { state in
+                                self.setState { state in
                                     state.alertsWithPendingAcknowledgment.insert(alert)
                                 }
                                 completion(error)
                                 return
                             }
-                            self.mutateState { state in
+                            self.setState { state in
                                 state.activeAlerts.remove(alert)
                             }
                             completion(nil)
                         case .failure(let error):
-                            self.mutateState { state in
+                            self.setState { state in
                                 state.alertsWithPendingAcknowledgment.insert(alert)
                             }
                             completion(error)
@@ -2319,7 +2555,7 @@ extension OmniBLEPumpManager {
                     }
                 } else {
                     // Non-pod alert
-                    self.mutateState { state in
+                    self.setState { state in
                         state.activeAlerts.remove(alert)
                         if alert == .timeOffsetChangeDetected {
                             state.acknowledgedTimeOffsetAlert = true

--- a/OmniBLE/PumpManager/OmniBLEPumpManagerState.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManagerState.swift
@@ -30,6 +30,8 @@ public struct OmniBLEPumpManagerState: RawRepresentable, Equatable {
 
     public var unstoredDoses: [UnfinalizedDose]
 
+    public var silencePod: Bool
+
     public var confirmationBeeps: BeepPreference
     
     public var controllerId: UInt32 = 0
@@ -96,6 +98,7 @@ public struct OmniBLEPumpManagerState: RawRepresentable, Equatable {
         self.timeZone = timeZone
         self.basalSchedule = basalSchedule
         self.unstoredDoses = []
+        self.silencePod = false
         self.confirmationBeeps = .manualCommands
         if controllerId != nil && podId != nil {
             self.controllerId = controllerId!
@@ -192,6 +195,8 @@ public struct OmniBLEPumpManagerState: RawRepresentable, Equatable {
             self.unstoredDoses = []
         }
 
+        self.silencePod = rawValue["silencePod"] as? Bool ?? false
+
         if let rawBeeps = rawValue["confirmationBeeps"] as? BeepPreference.RawValue, let confirmationBeeps = BeepPreference(rawValue: rawBeeps) {
             self.confirmationBeeps = confirmationBeeps
         } else {
@@ -246,6 +251,7 @@ public struct OmniBLEPumpManagerState: RawRepresentable, Equatable {
             "timeZone": timeZone.secondsFromGMT(),
             "basalSchedule": basalSchedule.rawValue,
             "unstoredDoses": unstoredDoses.map { $0.rawValue },
+            "silencePod": silencePod,
             "confirmationBeeps": confirmationBeeps.rawValue,
             "activeAlerts": activeAlerts.map { $0.rawValue },
             "podAttachmentConfirmed": podAttachmentConfirmed,
@@ -299,20 +305,24 @@ extension OmniBLEPumpManagerState: CustomDebugStringConvertible {
             "* tempBasalEngageState: \(String(describing: tempBasalEngageState))",
             "* lastPumpDataReportDate: \(String(describing: lastPumpDataReportDate))",
             "* isPumpDataStale: \(String(describing: isPumpDataStale))",
+            "* silencePod: \(String(describing: silencePod))",
             "* confirmationBeeps: \(String(describing: confirmationBeeps))",
             "* controllerId: \(String(format: "%08X", controllerId))",
             "* podId: \(String(format: "%08X", podId))",
             "* insulinType: \(String(describing: insulinType))",
-            "* scheduledExpirationReminderOffset: \(String(describing: scheduledExpirationReminderOffset))",
-            "* defaultExpirationReminderOffset: \(defaultExpirationReminderOffset)",
+            "* scheduledExpirationReminderOffset: \(String(describing: scheduledExpirationReminderOffset?.timeIntervalStr))",
+            "* defaultExpirationReminderOffset: \(defaultExpirationReminderOffset.timeIntervalStr)",
             "* lowReservoirReminderValue: \(lowReservoirReminderValue)",
             "* podAttachmentConfirmed: \(podAttachmentConfirmed)",
             "* activeAlerts: \(activeAlerts)",
             "* alertsWithPendingAcknowledgment: \(alertsWithPendingAcknowledgment)",
             "* acknowledgedTimeOffsetAlert: \(acknowledgedTimeOffsetAlert)",
             "* initialConfigurationCompleted: \(initialConfigurationCompleted)",
-            String(reflecting: podState),
-            "* PreviousPodState: \(String(reflecting: previousPodState))"
+            "",
+            "* PodState: " + (podState == nil ? "nil" : String(describing: podState!)),
+            "",
+            "* PreviousPodState: " + (previousPodState == nil ? "nil" : String(describing: previousPodState!)),
+            "",
         ].joined(separator: "\n")
     }
 }

--- a/OmniBLE/PumpManager/PodCommsSession.swift
+++ b/OmniBLE/PumpManager/PodCommsSession.swift
@@ -386,11 +386,22 @@ public class PodCommsSession {
         podState.finalizedDoses.append(UnfinalizedDose(resumeStartTime: currentDate, scheduledCertainty: .certain, insulinType: podState.insulinType))
     }
 
+    // Configures the given pod alert(s) and registers the newly configured alert slot(s).
+    // When re-configuring all the pod alerts for a silence pod toggle, the optional acknowledgeAll can be
+    // specified to first acknowledge and clear all possible pending pod alerts and pod alert configurations.
     @discardableResult
-    func configureAlerts(_ alerts: [PodAlert], beepBlock: MessageBlock? = nil) throws -> StatusResponse {
+    func configureAlerts(_ alerts: [PodAlert], acknowledgeAll: Bool = false, beepBlock: MessageBlock? = nil) throws -> StatusResponse {
         let configurations = alerts.map { $0.configuration }
         let configureAlerts = ConfigureAlertsCommand(nonce: podState.currentNonce, configurations: configurations)
-        let status: StatusResponse = try send([configureAlerts], beepBlock: beepBlock)
+        let blocksToSend: [MessageBlock]
+        if acknowledgeAll {
+            // Do the acknowledgeAllAlerts command first to clear all previous pod alert configurations.
+            let acknowledgeAllAlerts = AcknowledgeAlertCommand(nonce: podState.currentNonce, alerts: AlertSet(rawValue: ~0))
+            blocksToSend = [acknowledgeAllAlerts, configureAlerts]
+        } else {
+            blocksToSend = [configureAlerts]
+        }
+        let status: StatusResponse = try send(blocksToSend, beepBlock: beepBlock)
         for alert in alerts {
             podState.registerConfiguredAlert(slot: alert.configuration.slot, alert: alert)
         }
@@ -423,10 +434,10 @@ public class PodCommsSession {
         }
     }
 
-    public func insertCannula(optionalAlerts: [PodAlert] = []) throws -> TimeInterval {
+    public func insertCannula(optionalAlerts: [PodAlert] = [], silent: Bool) throws -> TimeInterval {
         let cannulaInsertionUnits = Pod.cannulaInsertionUnits + Pod.cannulaInsertionUnitsExtra
 
-        guard let activatedAt = podState.activatedAt else {
+        guard podState.activatedAt != nil else {
             throw PodCommsError.noPodPaired
         }
 
@@ -446,12 +457,12 @@ public class PodCommsSession {
             }
             podState.updateFromStatusResponse(status, at: currentDate)
         } else {
-            // Configure all the non-optional Pod Alarms
-            let expirationTime = activatedAt + Pod.nominalPodLife
-            let timeUntilExpirationAdvisory = expirationTime.timeIntervalSinceNow
-            let expirationAdvisoryAlarm = PodAlert.expired(alertTime: timeUntilExpirationAdvisory, duration: Pod.expirationAdvisoryWindow)
-            let endOfServiceTime = activatedAt + Pod.serviceDuration
-            let shutdownImminentAlarm = PodAlert.shutdownImminent((endOfServiceTime - Pod.endOfServiceImminentWindow).timeIntervalSinceNow)
+            let elapsed: TimeInterval = -(podState.podTimeUpdated?.timeIntervalSinceNow ?? 0)
+            let podTime = podState.podTime + elapsed
+
+            // Configure the mandatory Pod Alerts for shutdown imminent alert (79 hours) and pod expiration alert (72 hours) along with any optional alerts
+            let shutdownImminentAlarm = PodAlert.shutdownImminent(offset: podTime, absAlertTime: Pod.serviceDuration - Pod.endOfServiceImminentWindow, silent: silent)
+            let expirationAdvisoryAlarm = PodAlert.expired(offset: podTime, absAlertTime: Pod.nominalPodLife, duration: Pod.expirationAdvisoryWindow, silent: silent)
             try configureAlerts([expirationAdvisoryAlarm, shutdownImminentAlarm] + optionalAlerts)
         }
         
@@ -608,7 +619,8 @@ public class PodCommsSession {
     // A suspendReminder of 0 is an untimed suspend which only uses podSuspendedReminder alert beeps.
     // A suspendReminder of 1-5 minutes will only use suspendTimeExpired alert beeps.
     // A suspendReminder of > 5 min will have periodic podSuspendedReminder beeps followed by suspendTimeExpired alerts.
-    public func suspendDelivery(suspendReminder: TimeInterval? = nil, beepBlock: MessageBlock? = nil) -> CancelDeliveryResult {
+    // The configured alerts will set up as silent pod alerts if silent is true.
+    public func suspendDelivery(suspendReminder: TimeInterval? = nil, silent: Bool, beepBlock: MessageBlock? = nil) -> CancelDeliveryResult {
 
         guard podState.unacknowledgedCommand == nil else {
             return .certainFailure(error: .unacknowledgedCommandPending)
@@ -624,6 +636,9 @@ public class PodCommsSession {
             var podSuspendedReminderAlert: PodAlert? = nil
             var suspendTimeExpiredAlert: PodAlert? = nil
             let suspendTime: TimeInterval = suspendReminder != nil ? suspendReminder! : 0
+            let elapsed: TimeInterval = -(podState.podTimeUpdated?.timeIntervalSinceNow ?? 0)
+            let podTime = podState.podTime + elapsed
+            log.debug("suspendDelivery: podState.podTime=%@, elapsed=%.2fs, computed timeActive %@", podState.podTime.timeIntervalStr, elapsed, podTime.timeIntervalStr)
 
             let cancelDeliveryCommand = CancelDeliveryCommand(nonce: podState.currentNonce, deliveryType: .all, beepType: .noBeepCancel)
             var commandsToSend: [MessageBlock] = [cancelDeliveryCommand]
@@ -631,14 +646,14 @@ public class PodCommsSession {
             // podSuspendedReminder provides a periodic pod suspended reminder beep until the specified suspend time.
             if suspendReminder != nil && (suspendTime == 0 || suspendTime > .minutes(5)) {
                 // using reminder beeps for an untimed or long enough suspend time requiring pod suspended reminders
-                podSuspendedReminderAlert = PodAlert.podSuspendedReminder(active: true, suspendTime: suspendTime)
+                podSuspendedReminderAlert = PodAlert.podSuspendedReminder(active: true, offset: podTime, suspendTime: suspendTime, silent: silent)
                 alertConfigurations += [podSuspendedReminderAlert!.configuration]
             }
 
             // suspendTimeExpired provides suspend time expired alert beeping after the expected suspend time has passed.
             if suspendTime > 0 {
                 // a timed suspend using a suspend time expired alert
-                suspendTimeExpiredAlert = PodAlert.suspendTimeExpired(suspendTime: suspendTime)
+                suspendTimeExpiredAlert = PodAlert.suspendTimeExpired(offset: podTime, suspendTime: suspendTime, silent: silent)
                 alertConfigurations += [suspendTimeExpiredAlert!.configuration]
             }
 
@@ -678,8 +693,8 @@ public class PodCommsSession {
     private func cancelSuspendAlerts() throws -> StatusResponse {
 
         do {
-            let podSuspendedReminder = PodAlert.podSuspendedReminder(active: false, suspendTime: 0)
-            let suspendTimeExpired = PodAlert.suspendTimeExpired(suspendTime: 0) // A suspendTime of 0 deactivates this alert
+            let podSuspendedReminder = PodAlert.podSuspendedReminder(active: false, offset: 0, suspendTime: 0)
+            let suspendTimeExpired = PodAlert.suspendTimeExpired(offset: 0, suspendTime: 0) // A suspendTime of 0 deactivates this alert
 
             let status = try configureAlerts([podSuspendedReminder, suspendTimeExpired])
             return status
@@ -941,11 +956,11 @@ public class PodCommsSession {
         }
     }
     
-    public func acknowledgeAlerts(alerts: AlertSet, beepBlock: MessageBlock? = nil) throws -> [AlertSlot: PodAlert] {
+    public func acknowledgeAlerts(alerts: AlertSet, beepBlock: MessageBlock? = nil) throws -> AlertSet {
         let cmd = AcknowledgeAlertCommand(nonce: podState.currentNonce, alerts: alerts)
         let status: StatusResponse = try send([cmd], beepBlock: beepBlock)
         podState.updateFromStatusResponse(status, at: currentDate)
-        return podState.activeAlerts
+        return podState.activeAlertSlots
     }
 
     func dosesForStorage(_ storageHandler: ([UnfinalizedDose]) -> Bool) {

--- a/OmniBLE/PumpManagerUI/ViewControllers/DashUICoordinator.swift
+++ b/OmniBLE/PumpManagerUI/ViewControllers/DashUICoordinator.swift
@@ -169,7 +169,7 @@ class DashUICoordinator: UINavigationController, PumpManagerOnboarding, Completi
             viewModel.navigateTo = { [weak self] (screen) in
                 self?.navigateTo(screen)
             }
-            let view = OmniBLESettingsView(viewModel: viewModel, supportedInsulinTypes: allowedInsulinTypes)
+            let view = OmniBLESettingsView(viewModel: viewModel, supportedInsulinTypes: allowedInsulinTypes, allowDebugFeatures: allowDebugFeatures)
             return hostingController(rootView: view)
         case .pairAndPrime:
             pumpManagerOnboardingDelegate?.pumpManagerOnboarding(didCreatePumpManager: pumpManager)

--- a/OmniBLE/PumpManagerUI/Views/ActivityView.swift
+++ b/OmniBLE/PumpManagerUI/Views/ActivityView.swift
@@ -1,0 +1,36 @@
+//
+//  ActivityView.swift
+//  OmniBLE
+//
+//  Created by Joe Moran on 9/17/23.
+//  Copyright © 2023 LoopKit Authors. All rights reserved.
+//
+
+import SwiftUI
+
+struct ActivityView: UIViewControllerRepresentable {
+    @Binding var isPresented: Bool
+    let activityItems: [Any]
+
+    func makeUIViewController(context: UIViewControllerRepresentableContext<ActivityView>) -> UIActivityViewController {
+        let controller = UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
+        controller.completionWithItemsHandler = { (_, _, _, _) in
+            self.isPresented = false
+        }
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: UIViewControllerRepresentableContext<ActivityView>) {
+    }
+}
+
+fileprivate struct ActivityViewController: UIViewControllerRepresentable {
+    var activityItems: [Any]
+    var applicationActivities: [UIActivity]? = nil
+
+    func makeUIViewController(context: UIViewControllerRepresentableContext<ActivityViewController>) -> UIActivityViewController {
+        return UIActivityViewController(activityItems: activityItems, applicationActivities: applicationActivities)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: UIViewControllerRepresentableContext<ActivityViewController>) {}
+}

--- a/OmniBLE/PumpManagerUI/Views/FirstAppear.swift
+++ b/OmniBLE/PumpManagerUI/Views/FirstAppear.swift
@@ -1,0 +1,30 @@
+//
+//  FirstAppear.swift
+//  OmniBLE
+//
+//  Created by Joe Moran on 9/24/23.
+//  Copyright © 2023 LoopKit Authors. All rights reserved.
+//
+
+import SwiftUI
+
+extension View {
+    func onFirstAppear(_ action: @escaping () -> ()) -> some View {
+        modifier(FirstAppear(action: action))
+    }
+}
+
+private struct FirstAppear: ViewModifier {
+    let action: () -> ()
+
+    // State used to insure action is invoked here only once
+    @State private var hasAppeared = false
+
+    func body(content: Content) -> some View {
+        content.onAppear {
+            guard !hasAppeared else { return }
+            hasAppeared = true
+            action()
+        }
+    }
+}

--- a/OmniBLE/PumpManagerUI/Views/OmniBLESettingsView.swift
+++ b/OmniBLE/PumpManagerUI/Views/OmniBLESettingsView.swift
@@ -32,6 +32,8 @@ struct OmniBLESettingsView: View  {
     @Environment(\.guidanceColors) var guidanceColors
     @Environment(\.insulinTintColor) var insulinTintColor
     
+    let allowDebugFeatures : Bool
+
     private var daysRemaining: Int? {
         if case .timeRemaining(let remaining, _) = viewModel.lifeState, remaining > .days(1) {
             return Int(remaining.days)
@@ -343,8 +345,8 @@ struct OmniBLESettingsView: View  {
                     manualTempBasalRow
                 }
             }
-            .disabled(cancelingTempBasal)
-            
+            .disabled(cancelingTempBasal || !self.viewModel.podOk)
+
             Section() {
                 HStack {
                     FrameworkLocalText("Pod Activated", comment: "Label for pod insertion row")
@@ -352,7 +354,7 @@ struct OmniBLESettingsView: View  {
                     Text(self.viewModel.activatedAtString)
                         .foregroundColor(Color.secondary)
                 }
-                
+
                 HStack {
                     if let expiresAt = viewModel.expiresAt, expiresAt < Date() {
                         FrameworkLocalText("Pod Expired", comment: "Label for pod expiration row, past tense")
@@ -363,21 +365,36 @@ struct OmniBLESettingsView: View  {
                     Text(self.viewModel.expiresAtString)
                         .foregroundColor(Color.secondary)
                 }
-                
+
                 if let podDetails = self.viewModel.podDetails {
-                    NavigationLink(destination: PodDetailsView(podDetails: podDetails, title: LocalizedString("Device Details", comment: "title for device details page"))) {
-                        FrameworkLocalText("Device Details", comment: "Text for device details disclosure row").foregroundColor(Color.primary)
+                    NavigationLink(destination: PodDetailsView(podDetails: podDetails, title: LocalizedString("Pod Details", comment: "title for pod details page"))) {
+                        FrameworkLocalText("Pod Details", comment: "Text for pod details disclosure row")
+                            .foregroundColor(Color.primary)
                     }
                 } else {
                     HStack {
-                        FrameworkLocalText("Device Details", comment: "Text for device details disclosure row")
+                        FrameworkLocalText("Pod Details", comment: "Text for pod details disclosure row")
+                        Spacer()
+                        Text("—")
+                            .foregroundColor(Color.secondary)
+                    }
+                }
+
+                if let previousPodDetails = viewModel.previousPodDetails {
+                    NavigationLink(destination: PodDetailsView(podDetails: previousPodDetails, title: LocalizedString("Previous Pod", comment: "title for previous pod page"))) {
+                        FrameworkLocalText("Previous Pod Details", comment: "Text for previous pod details row")
+                            .foregroundColor(Color.primary)
+                    }
+                } else {
+                    HStack {
+                        FrameworkLocalText("Previous Pod Details", comment: "Text for previous pod details row")
                         Spacer()
                         Text("—")
                             .foregroundColor(Color.secondary)
                     }
                 }
             }
-            
+
             Section() {
                 Button(action: {
                     self.viewModel.navigateTo?(self.viewModel.lifeState.nextPodLifecycleAction)
@@ -386,7 +403,7 @@ struct OmniBLESettingsView: View  {
                         .foregroundColor(self.viewModel.lifeState.nextPodLifecycleActionColor)
                 }
             }
-            
+
             Section(header: SectionHeader(label: LocalizedString("Configuration", comment: "Section header for configuration section")))
             {
                 NavigationLink(destination:
@@ -403,15 +420,27 @@ struct OmniBLESettingsView: View  {
                 }
                 NavigationLink(destination: BeepPreferenceSelectionView(initialValue: viewModel.beepPreference, onSave: viewModel.setConfirmationBeeps)) {
                     HStack {
-                        FrameworkLocalText("Confidence Reminders", comment: "Text for confidence reminders navigation link").foregroundColor(Color.primary)
+                        FrameworkLocalText("Confidence Reminders", comment: "Text for confidence reminders navigation link")
+                            .foregroundColor(Color.primary)
                         Spacer()
                         Text(viewModel.beepPreference.title)
                             .foregroundColor(.secondary)
                     }
                 }
+                if  (allowDebugFeatures) {
+                    NavigationLink(destination: SilencePodSelectionView(initialValue: viewModel.silencePodPreference, onSave: viewModel.setSilencePod)) {
+                        HStack {
+                            FrameworkLocalText("Silence Pod", comment: "Text for silence pod navigation link")
+                                .foregroundColor(Color.primary)
+                            Spacer()
+                            Text(viewModel.silencePodPreference.title)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
                 NavigationLink(destination: InsulinTypeSetting(initialValue: viewModel.insulinType, supportedInsulinTypes: supportedInsulinTypes, allowUnsetInsulinType: false, didChange: viewModel.didChangeInsulinType)) {
                     HStack {
-                        FrameworkLocalText("Insulin Type", comment: "Text for confidence reminders navigation link").foregroundColor(Color.primary)
+                        FrameworkLocalText("Insulin Type", comment: "Text for insulin type navigation link").foregroundColor(Color.primary)
                         if let currentTitle = viewModel.insulinType?.brandName {
                             Spacer()
                             Text(currentTitle)
@@ -420,7 +449,7 @@ struct OmniBLESettingsView: View  {
                     }
                 }
             }
-            
+
             Section() {
                 HStack {
                     FrameworkLocalText("Pump Time", comment: "The title of the command to change pump time zone")
@@ -451,14 +480,17 @@ struct OmniBLESettingsView: View  {
                 }
             }
 
-            if let previousPodDetails = viewModel.previousPodDetails {
+            if  (allowDebugFeatures) {
                 Section() {
-                    NavigationLink(destination: PodDetailsView(podDetails: previousPodDetails, title: LocalizedString("Previous Pod", comment: "title for previous pod page"))) {
-                        FrameworkLocalText("Previous Pod Information", comment: "Text for previous pod information row").foregroundColor(Color.primary)
+                    NavigationLink(destination: PodDiagnosticsView(
+                        title: LocalizedString("Pod Diagnostics", comment: "Title for the pod diagnostic view"),
+                        viewModel: viewModel))
+                    {
+                        FrameworkLocalText("Pod Diagnostics", comment: "Text for pod diagnostics row")
+                            .foregroundColor(Color.primary)
                     }
                 }
             }
-            
 
             if self.viewModel.lifeState.allowsPumpManagerRemoval {
                 Section() {
@@ -501,7 +533,7 @@ struct OmniBLESettingsView: View  {
     var suspendOptionsActionSheet: ActionSheet {
         ActionSheet(
             title: FrameworkLocalText("Suspend Delivery", comment: "Title for suspend duration selection action sheet"),
-            message: FrameworkLocalText("Insulin delivery will be stopped until you resume manually. When would you like Loop to remind you to resume delivery?", comment: "Message for suspend duration selection action sheet"),
+            message: FrameworkLocalText("Insulin delivery will be stopped until you resume manually. When would you like this app to remind you to resume delivery?", comment: "Message for suspend duration selection action sheet"),
             buttons: [
                 .default(FrameworkLocalText("30 minutes", comment: "Button text for 30 minute suspend duration"), action: { self.viewModel.suspendDelivery(duration: .minutes(30)) }),
                 .default(FrameworkLocalText("1 hour", comment: "Button text for 1 hour suspend duration"), action: { self.viewModel.suspendDelivery(duration: .hours(1)) }),

--- a/OmniBLE/PumpManagerUI/Views/PlayTestBeepsView.swift
+++ b/OmniBLE/PumpManagerUI/Views/PlayTestBeepsView.swift
@@ -1,0 +1,100 @@
+//
+//  PlayTestBeepsView.swift
+//  OmniBLE
+//
+//  Created by Joe Moran on 9/1/23.
+//  Copyright © 2023 LoopKit Authors. All rights reserved.
+//
+
+import SwiftUI
+import LoopKit
+
+
+struct PlayTestBeepsView: View {
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
+    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+
+    var toRun: ((_ completion: @escaping (_ result: Error?) -> Void) -> Void)?
+
+    private let title = LocalizedString("Play Test Beeps", comment: "navigation title for play test beeps")
+    private let actionString = LocalizedString("Playing Test Beeps...", comment: "button title when executing play test beeps")
+    private let failedString: String = LocalizedString("Failed to play test beeps.", comment: "Alert title for error when playing test beeps")
+
+    @State private var alertIsPresented: Bool = false
+    @State private var displayString: String = ""
+    @State private var successMessage = LocalizedString("Play test beeps command sent successfully.\n\nIf you did not hear any beeps from your Pod, the piezo speaker in your Pod may be broken or disabled.", comment: "Success message for play test beeps")
+    @State private var error: Error? = nil
+    @State private var executing: Bool = false
+    @State private var showActivityView = false
+
+    var body: some View {
+        VStack {
+            List {
+                Section {
+                    Text(self.displayString).fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            VStack {
+                Button(action: {
+                    asyncAction()
+                }) {
+                    Text(buttonText)
+                        .actionButtonStyle(.primary)
+                }
+                .padding()
+                .disabled(executing)
+            }
+            .padding(self.horizontalSizeClass == .regular ? .bottom : [])
+            .background(Color(UIColor.secondarySystemGroupedBackground).shadow(radius: 5))
+        }
+        .insetGroupedListStyle()
+        .navigationTitle(title)
+        .navigationBarTitleDisplayMode(.inline)
+        .alert(isPresented: $alertIsPresented, content: { alert(error: error) })
+        .onFirstAppear {
+            asyncAction()
+        }
+    }
+
+    private func asyncAction () {
+        DispatchQueue.global(qos: .utility).async {
+            executing = true
+            self.displayString = ""
+            toRun?() { (error) in
+                executing = false
+                if let error = error {
+                    self.displayString = ""
+                    self.error = error
+                    self.alertIsPresented = true
+                } else {
+                    self.displayString = successMessage
+                }
+            }
+        }
+    }
+
+    private var buttonText: String {
+        if executing {
+            return actionString
+        } else {
+            return title
+        }
+    }
+
+    private func alert(error: Error?) -> SwiftUI.Alert {
+        return SwiftUI.Alert(
+            title: Text(failedString),
+            message: Text(error?.localizedDescription ?? "No Error")
+        )
+    }
+}
+
+struct PlayTestBeepsView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            PlayTestBeepsView() { completion in
+                completion(nil)
+            }
+        }
+    }
+}

--- a/OmniBLE/PumpManagerUI/Views/PodDiagnostics.swift
+++ b/OmniBLE/PumpManagerUI/Views/PodDiagnostics.swift
@@ -1,0 +1,89 @@
+//
+//  PodDiagnotics.swift
+//  OmniBLE
+//
+//  Created by Joseph Moran on 11/25/23.
+//  Copyright © 2023 LoopKit Authors. All rights reserved.
+//
+
+import SwiftUI
+import LoopKit
+import LoopKitUI
+import HealthKit
+
+
+struct PodDiagnosticsView: View  {
+
+    var title: String
+    
+    @ObservedObject var viewModel: OmniBLESettingsViewModel
+
+    var body: some View {
+        List {
+            NavigationLink(destination: ReadPodStatusView(toRun: viewModel.readPodStatus)) {
+                FrameworkLocalText("Read Pod Status", comment: "Text for read pod status navigation link")
+                    .foregroundColor(Color.primary)
+            }
+            .disabled(self.viewModel.noPod)
+
+            NavigationLink(destination: PlayTestBeepsView(toRun: viewModel.playTestBeeps)) {
+                FrameworkLocalText("Play Test Beeps", comment: "Text for play test beeps navigation link")
+                    .foregroundColor(Color.primary)
+            }
+            .disabled(!self.viewModel.podOk)
+
+            NavigationLink(destination: ReadPodInfoView(
+                title: LocalizedString("Read Pulse Log", comment: "Text for read pulse log title"),
+                actionString: LocalizedString("Reading Pulse Log...", comment: "Text for read pulse log action"),
+                failedString: LocalizedString("Failed to read pulse log.", comment: "Alert title for error when reading pulse log"),
+                toRun: viewModel.readPulseLog))
+            {
+                FrameworkLocalText("Read Pulse Log", comment: "Text for read pulse log navigation link")
+                    .foregroundColor(Color.primary)
+            }
+            .disabled(self.viewModel.noPod)
+
+            NavigationLink(destination: ReadPodInfoView(
+                title: LocalizedString("Read Pulse Log Plus", comment: "Text for read pulse log plus title"),
+                actionString: LocalizedString("Reading Pulse Log Plus...", comment: "Text for read pulse log plus action"),
+                failedString: LocalizedString("Failed to read pulse log plus.", comment: "Alert title for error when reading pulse log plus"),
+                toRun: viewModel.readPulseLogPlus))
+            {
+                FrameworkLocalText("Read Pulse Log Plus", comment: "Text for read pulse log plus navigation link")
+                    .foregroundColor(Color.primary)
+            }
+            .disabled(self.viewModel.noPod)
+
+            NavigationLink(destination: ReadPodInfoView(
+                title: LocalizedString("Read Activation Time", comment: "Text for read activation time title"),
+                actionString: LocalizedString("Reading Activation Time...", comment: "Text for read activation time action"),
+                failedString: LocalizedString("Failed to read activation time.", comment: "Alert title for error when reading activation time"),
+                toRun: self.viewModel.readActivationTime))
+            {
+                FrameworkLocalText("Read Activation Time", comment: "Text for read activation time navigation link")
+                    .foregroundColor(Color.primary)
+            }
+            .disabled(self.viewModel.noPod)
+
+            NavigationLink(destination: ReadPodInfoView(
+                title: LocalizedString("Read Triggered Alerts", comment: "Text for read triggered alerts title"),
+                actionString: LocalizedString("Reading Triggered Alerts...", comment: "Text for read triggered alerts action"),
+                failedString: LocalizedString("Failed to read triggered alerts.", comment: "Alert title for error when reading triggered alerts"),
+                toRun: self.viewModel.readTriggeredAlerts))
+            {
+                FrameworkLocalText("Read Triggered Alerts", comment: "Text for read triggered alerts navigation link")
+                    .foregroundColor(Color.primary)
+            }
+            .disabled(self.viewModel.noPod)
+
+            NavigationLink(destination: PumpManagerDetailsView(
+                toRun: self.viewModel.pumpManagerDetails))
+            {
+                FrameworkLocalText("Pump Manager Details", comment: "Text for pump manager details navigation link")
+                    .foregroundColor(Color.primary)
+            }
+        }
+        .insetGroupedListStyle()
+        .navigationBarTitle(title)
+    }
+}

--- a/OmniBLE/PumpManagerUI/Views/PumpManagerDetailsView.swift
+++ b/OmniBLE/PumpManagerUI/Views/PumpManagerDetailsView.swift
@@ -1,0 +1,104 @@
+//
+//  PumpManagerDetailsView.swift
+//  OmniBLE
+//
+//  Created by Joe Moran on 9/26/23.
+//  Copyright © 2023 LoopKit Authors. All rights reserved.
+//
+
+import SwiftUI
+import LoopKit
+
+
+struct PumpManagerDetailsView: View {
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
+    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+
+    var toRun: ((_ completion: @escaping (_ result: String) -> Void) -> Void)?
+
+    private let title = LocalizedString("Pump Manager Details", comment: "navigation title for pump manager details")
+    private let actionString = LocalizedString("Retrieving Pump Manager Details...", comment: "button title when retrieving pump manager details")
+    private let buttonTitle = LocalizedString("Refresh Pump Manager Details", comment: "button title to refresh pump manager details")
+
+    @State private var displayString: String = ""
+    @State private var error: Error? = nil
+    @State private var executing: Bool = false
+    @State private var showActivityView: Bool = false
+
+    init(toRun: @escaping (_ completion: @escaping (_ result: String) -> Void) -> Void) {
+        self.toRun = toRun
+    }
+
+    var body: some View {
+        VStack {
+            List {
+                Section {
+                    let myFont = Font
+                        .system(size: 12)
+                        .monospaced()
+                    Text(self.displayString)
+                        .font(myFont)
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: {
+                        self.showActivityView = true
+                    }) {
+                        Image(systemName: "square.and.arrow.up")
+                    }
+                }
+            }.sheet(isPresented: $showActivityView) {
+                ActivityView(isPresented: $showActivityView, activityItems: [self.displayString])
+            }
+            VStack {
+                Button(action: {
+                    asyncAction()
+                }) {
+                    Text(buttonText)
+                        .actionButtonStyle(.primary)
+                }
+                .padding()
+                .disabled(executing)
+            }
+            .padding(self.horizontalSizeClass == .regular ? .bottom : [])
+            .background(Color(UIColor.secondarySystemGroupedBackground).shadow(radius: 5))
+        }
+        .insetGroupedListStyle()
+        .navigationTitle(title)
+        .navigationBarTitleDisplayMode(.inline)
+        .onFirstAppear {
+            asyncAction()
+        }
+    }
+
+    private func asyncAction () {
+        DispatchQueue.global(qos: .utility).async {
+            executing = true
+            self.displayString = ""
+            toRun?() { (result) in
+                self.displayString = result
+                executing = false
+            }
+        }
+    }
+
+    private var buttonText: String {
+        if executing {
+            return actionString
+        } else {
+            return buttonTitle
+        }
+    }
+}
+
+struct PumpManagerDetailsView_Previews: PreviewProvider {
+    static var previews: some View {
+        let examplePumpManagerDetails: String = "## OmniBLEPumpManager\nprovideHeartbeat: false\nconnected: true\n\npodComms: ## PodComms\n* myId: 171637F8\n* podId: 171637FB\ndelegate: true\n\nstatusObservers.count: 2\nstatus: ## PumpManagerStatus\n* timeZone: GMT-0700 (fixed)\n* device: <<HKDevice: 0x282f25130>, name:Omnipod-Dash, manufacturer:Insulet, model:Dash, hardware:4, firmware:4.10.0 1.4.0, software:1.0, localIdentifier:171637FB>\n* pumpBatteryChargeRemaining: nil\n* basalDeliveryState: Optional(LoopKit.PumpManagerStatus.BasalDeliveryState.tempBasal(LoopKit.DoseEntry(type: LoopKit.DoseType.tempBasal, startDate: 2023-10-08 00:21:42 +0000, endDate: 2023-10-08 00:51:42 +0000, value: 1.55, unit: LoopKit.DoseUnit.unitsPerHour, deliveredUnits: nil, description: nil, insulinType: Optional(LoopKit.InsulinType.humalog), automatic: Optional(true), manuallyEntered: false, syncIdentifier: nil, isMutable: true, wasProgrammedByPumpUI: false, scheduledBasalRate: nil)))\n* bolusState: noBolus\n* insulinType: Optional(LoopKit.InsulinType.humalog)\n* deliveryIsUncertain: false\n\npodStateObservers.count: 1\nstate: ## OmniBLEPumpManagerState\n* isOnboarded: true\n* timeZone: GMT-0700 (fixed)\n* basalSchedule: BasalSchedule(entries: [OmniBLE.BasalScheduleEntry(rate: 1.0, startTime: 0.0)])\n* maximumTempBasalRate: 5.0\n* unstoredDoses: []\n* suspendEngageState: stable\n* bolusEngageState: stable\n* tempBasalEngageState: stable\n* lastPumpDataReportDate: Optional(2023-09-28 14:03:50 +0000)\n* isPumpDataStale: false\n* silencePod: true\n* confirmationBeeps: extended\n* controllerId: 171637F8\n* podId: 171637FB\n* insulinType: Optional(LoopKit.InsulinType.humalog)\n* scheduledExpirationReminderOffset: Optional(22h0m)\n* defaultExpirationReminderOffset: 24h0m\n* lowReservoirReminderValue: 50.0\n* podAttachmentConfirmed: true\n* activeAlerts: []\n* alertsWithPendingAcknowledgment: []\n* acknowledgedTimeOffsetAlert: false\n* initialConfigurationCompleted: true\n* podState: ### PodState\n* address: 171637FB\n* bleIdentifier: 20672963-16E5-D8F8-9C06-1233FEAA61EB\n* activatedAt: Optional(2023-09-25 06:04:36 +0000)\n* expiresAt: Optional(2023-09-28 06:02:46 +0000)\n* timeActive: 79h59m\n* timeActiveUpdated: Optional(2023-09-28 14:03:50 +0000)\n* setupUnitsDelivered: Optional(2.8)\n* firmwareVersion: 4.10.0\n* bleFirmwareVersion: 1.4.0\n* lotNo: 139865265\n* lotSeq: 2770428\n* suspendState: suspended(2023-09-28 14:02:47 +0000)\n* unacknowledgedCommand: nil\n* unfinalizedBolus: nil\n* unfinalizedTempBasal: nil\n* unfinalizedSuspend: Optional(Suspend: 9/28/23, 7:02:47 AM Certain)\n* unfinalizedResume: Optional(Resume: 9/24/23, 11:06:33 PM Certain)\n* finalizedDoses: []\n* activeAlertsSlots: No alerts\n* messageTransportState: ##\nMessageTransportState\neapSeq: 1059\nmsgSeq: 7\nnonceSeq: 6\nmessageNumber: 14\n* setupProgress: completed\n* primeFinishTime: Optional(2023-10-05 05:46:46 +0000)\n* configuredAlerts: [OmniBLE.AlertSlot.slot7Expired: Pod expired, OmniBLE.AlertSlot.slot2ShutdownImminent: Shutdown imminent, OmniBLE.AlertSlot.slot3ExpirationReminder: Expiration reminder, OmniBLE.AlertSlot.slot4LowReservoir: Low reservoir]\n* insulinType: humalog\n* PdmRef: nil\n* Fault: nil\n\nPreviousPodState: nil"
+        NavigationView {
+            PumpManagerDetailsView() { completion in
+                completion(examplePumpManagerDetails)
+            }
+        }
+    }
+}

--- a/OmniBLE/PumpManagerUI/Views/ReadPodInfoView.swift
+++ b/OmniBLE/PumpManagerUI/Views/ReadPodInfoView.swift
@@ -1,0 +1,134 @@
+//
+//  ReadPodInfoView.swift
+//  OmniBLE
+//
+//  Created by Joe Moran on 11/25/23.
+//  Copyright © 2023 LoopKit Authors. All rights reserved.
+//
+
+import SwiftUI
+import LoopKit
+
+
+struct ReadPodInfoView: View {
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
+    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+
+    var title: String           // e.g., "Read Pulse Log"
+    var actionString: String    // e.g., "Reading Pulse Log..."
+    var failedString: String    // e.g., "Failed to read pulse log."
+
+    var toRun: ((_ completion: @escaping (_ result: Result<String, Error>) -> Void) -> Void)?
+
+    @State private var alertIsPresented: Bool = false
+    @State private var displayString: String = ""
+    @State private var error: Error? = nil
+    @State private var executing: Bool = false
+    @State private var showActivityView: Bool = false
+
+    var body: some View {
+        VStack {
+            List {
+                Section {
+                    let myFont = Font
+                        .system(size: 12)
+                        .monospaced()
+                    Text(self.displayString)
+                        .font(myFont)
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: {
+                        self.showActivityView = true
+                    }) {
+                        Image(systemName: "square.and.arrow.up")
+                    }
+                }
+            }.sheet(isPresented: $showActivityView) {
+                ActivityView(isPresented: $showActivityView, activityItems: [self.displayString])
+            }
+            VStack {
+                Button(action: {
+                    asyncAction()
+                }) {
+                    Text(buttonText)
+                        .actionButtonStyle(.primary)
+                }
+                .padding()
+                .disabled(executing)
+            }
+            .padding(self.horizontalSizeClass == .regular ? .bottom : [])
+            .background(Color(UIColor.secondarySystemGroupedBackground).shadow(radius: 5))
+        }
+        .insetGroupedListStyle()
+        .navigationTitle(title)
+        .navigationBarTitleDisplayMode(.inline)
+        .alert(isPresented: $alertIsPresented, content: { alert(error: error) })
+        .onFirstAppear {
+            asyncAction()
+        }
+    }
+
+    private func asyncAction () {
+        DispatchQueue.global(qos: .utility).async {
+            executing = true
+            self.displayString = ""
+            toRun?() { (result) in
+                executing = false
+                switch result {
+                case .success(let resultString):
+                    self.displayString = resultString
+                case .failure(let error):
+                    self.displayString = ""
+                    self.error = error
+                    self.alertIsPresented = true
+                }
+            }
+        }
+    }
+
+    private var buttonText: String {
+        if executing {
+            return actionString
+        } else {
+            return title
+        }
+    }
+
+    private func alert(error: Error?) -> SwiftUI.Alert {
+        return SwiftUI.Alert(
+            title: Text(failedString),
+            message: Text(error?.localizedDescription ?? "No Error")
+        )
+    }
+}
+
+struct ReadPodInfoView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            ReadPodInfoView(
+                title: "Read Pulse Log",
+                actionString: "Reading Pulse Log...",
+                failedString: "Failed to read pulse log"
+            ) { completion in
+                let podInfoPulseLogRecent = try! PodInfoPulseLogRecent(encodedData: Data([0x50, 0x03, 0x17,
+                    0x39, 0x72, 0x58, 0x01,  0x3c, 0x72, 0x43, 0x01,  0x41, 0x72, 0x5a, 0x01,  0x44, 0x71, 0x47, 0x01,
+                    0x49, 0x51, 0x59, 0x01,  0x4c, 0x51, 0x44, 0x01,  0x51, 0x73, 0x59, 0x01,  0x54, 0x50, 0x43, 0x01,
+                    0x59, 0x50, 0x5a, 0x81,  0x5c, 0x51, 0x42, 0x81,  0x61, 0x73, 0x59, 0x81,  0x00, 0x75, 0x43, 0x80,
+                    0x05, 0x70, 0x5a, 0x80,  0x08, 0x50, 0x44, 0x80,  0x0d, 0x50, 0x5b, 0x80,  0x10, 0x75, 0x43, 0x80,
+                    0x15, 0x72, 0x5e, 0x80,  0x18, 0x73, 0x45, 0x80,  0x1d, 0x72, 0x5b, 0x00,  0x20, 0x70, 0x43, 0x00,
+                    0x25, 0x50, 0x5c, 0x00,  0x28, 0x50, 0x46, 0x00,  0x2d, 0x50, 0x5a, 0x00,  0x30, 0x75, 0x47, 0x00,
+                    0x35, 0x72, 0x59, 0x00,  0x38, 0x70, 0x46, 0x00,  0x3d, 0x75, 0x57, 0x00,  0x40, 0x72, 0x43, 0x00,
+                    0x45, 0x73, 0x55, 0x00,  0x48, 0x73, 0x41, 0x00,  0x4d, 0x70, 0x52, 0x00,  0x50, 0x73, 0x3f, 0x00,
+                    0x55, 0x74, 0x4d, 0x00,  0x58, 0x72, 0x3d, 0x80,  0x5d, 0x73, 0x4d, 0x80,  0x60, 0x71, 0x3d, 0x80,
+                    0x01, 0x51, 0x50, 0x80,  0x04, 0x72, 0x3d, 0x80,  0x09, 0x50, 0x4e, 0x80,  0x0c, 0x51, 0x40, 0x80,
+                    0x11, 0x74, 0x50, 0x80,  0x14, 0x71, 0x40, 0x80,  0x19, 0x50, 0x4d, 0x80,  0x1c, 0x75, 0x3f, 0x00,
+                    0x21, 0x72, 0x52, 0x00,  0x24, 0x72, 0x40, 0x00,  0x29, 0x71, 0x53, 0x00,  0x2c, 0x50, 0x42, 0x00,
+                    0x31, 0x51, 0x55, 0x00,  0x34, 0x50, 0x42, 0x00   ]))
+                let lastPulseNumber = Int(podInfoPulseLogRecent.indexLastEntry)
+                completion(.success(pulseLogString(pulseLogEntries: podInfoPulseLogRecent.pulseLog, lastPulseNumber: lastPulseNumber)))
+            }
+        }
+    }
+}

--- a/OmniBLE/PumpManagerUI/Views/ReadPodStatusView.swift
+++ b/OmniBLE/PumpManagerUI/Views/ReadPodStatusView.swift
@@ -1,0 +1,168 @@
+//
+//  ReadPodStatusView.swift
+//  OmniBLE
+//
+//  Created by Joe Moran on 8/15/23.
+//  Copyright © 2023 LoopKit Authors. All rights reserved.
+//
+
+import SwiftUI
+import LoopKit
+
+
+struct ReadPodStatusView: View {
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
+    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+
+    var toRun: ((_ completion: @escaping (_ result: PumpManagerResult<DetailedStatus>) -> Void) -> Void)?
+
+    private let title = LocalizedString("Read Pod Status", comment: "navigation title for read pod status")
+    private let actionString = LocalizedString("Reading Pod Status...", comment: "button title when executing read pod status")
+    private let failedString = LocalizedString("Failed to read pod status.", comment: "Alert title for error when reading pod status")
+
+    @State private var alertIsPresented: Bool = false
+    @State private var displayString: String = ""
+    @State private var error: LocalizedError? = nil
+    @State private var executing: Bool = false
+    @State private var showActivityView: Bool = false
+
+    var body: some View {
+        VStack {
+            List {
+                Section {
+                    Text(self.displayString).fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: {
+                        self.showActivityView = true
+                    }) {
+                        Image(systemName: "square.and.arrow.up")
+                    }
+                }
+            }.sheet(isPresented: $showActivityView) {
+                ActivityView(isPresented: $showActivityView, activityItems: [self.displayString])
+            }
+            VStack {
+                Button(action: {
+                    asyncAction()
+                }) {
+                    Text(buttonText)
+                        .actionButtonStyle(.primary)
+                }
+                .padding()
+                .disabled(executing)
+            }
+            .padding(self.horizontalSizeClass == .regular ? .bottom : [])
+            .background(Color(UIColor.secondarySystemGroupedBackground).shadow(radius: 5))
+        }
+        .insetGroupedListStyle()
+        .navigationTitle(title)
+        .navigationBarTitleDisplayMode(.inline)
+        .alert(isPresented: $alertIsPresented, content: { alert(error: error) })
+        .onFirstAppear {
+            asyncAction()
+        }
+    }
+
+    private func asyncAction () {
+        DispatchQueue.global(qos: .utility).async {
+            executing = true
+            self.displayString = ""
+            toRun?() { (result) in
+                executing = false
+                switch result {
+                case .success(let detailedStatus):
+                    self.displayString = podStatusString(status: detailedStatus)
+                case .failure(let error):
+                    self.error = error
+                    self.alertIsPresented = true
+                }
+            }
+        }
+    }
+
+    private var buttonText: String {
+        if executing {
+            return actionString
+        } else {
+            return title
+        }
+    }
+
+    private func alert(error: Error?) -> SwiftUI.Alert {
+        return SwiftUI.Alert(
+            title: Text(failedString),
+            message: Text(error?.localizedDescription ?? "No Error")
+        )
+    }
+}
+
+private func podStatusString(status: DetailedStatus) -> String {
+    var result, str: String
+
+    let formatter = DateComponentsFormatter()
+    formatter.unitsStyle = .full
+    formatter.allowedUnits = [.hour, .minute]
+    formatter.unitsStyle = .short
+    if let timeStr = formatter.string(from: status.timeActive) {
+        str = timeStr
+    } else {
+        str = String(format: LocalizedString("%1$@ minutes", comment: "The format string for minutes (1: number of minutes string)"), String(describing: Int(status.timeActive / 60)))
+    }
+    result = String(format: LocalizedString("Pod Active: %1$@", comment: "The format string for Pod Active: (1: formatted time)"), str)
+
+    result += String(format: LocalizedString("\nPod Progress: %1$@", comment: "The format string for Pod Progress: (1: pod progress string)"), String(describing: status.podProgressStatus))
+
+    result += String(format: LocalizedString("\nDelivery Status: %1$@", comment: "The format string for Delivery Status: (1: delivery status string)"), String(describing: status.deliveryStatus))
+
+    result += String(format: LocalizedString("\nLast Programming Seq Num: %1$@", comment: "The format string for last programming sequence number: (1: last programming sequence number)"), String(describing: status.lastProgrammingMessageSeqNum))
+
+    result += String(format: LocalizedString("\nBolus Not Delivered: %1$@ U", comment: "The format string for Bolus Not Delivered: (1: bolus not delivered string)"), status.bolusNotDelivered.twoDecimals)
+
+    result += String(format: LocalizedString("\nPulse Count: %1$d", comment: "The format string for Pulse Count (1: pulse count)"), Int(round(status.totalInsulinDelivered / Pod.pulseSize)))
+
+    result += String(format: LocalizedString("\nReservoir Level: %1$@ U", comment: "The format string for Reservoir Level: (1: reservoir level string)"), status.reservoirLevel == Pod.reservoirLevelAboveThresholdMagicNumber ? "50+" : status.reservoirLevel.twoDecimals)
+
+    result += String(format: LocalizedString("\nAlerts: %1$@", comment: "The format string for Alerts: (1: the alerts string)"), alertSetString(alertSet: status.unacknowledgedAlerts))
+
+    if status.radioRSSI != 0 {
+        result += String(format: LocalizedString("\nRSSI: %1$@", comment: "The format string for RSSI: (1: RSSI value)"), String(describing: status.radioRSSI))
+        result += String(format: LocalizedString("\nReceiver Low Gain: %1$@", comment: "The format string for receiverLowGain: (1: receiverLowGain)"), String(describing: status.receiverLowGain))
+    }
+
+    if status.faultEventCode.faultType != .noFaults {
+        // report the additional fault related information in a separate section
+        result += String(format: LocalizedString("\n\n⚠️ Critical Pod Fault %1$03d (0x%2$02X)", comment: "The format string for fault code in decimal and hex: (1: fault code for decimal display) (2: fault code for hex display)"), status.faultEventCode.rawValue, status.faultEventCode.rawValue)
+        result += String(format: "\n%1$@", status.faultEventCode.faultDescription)
+        if let faultEventTimeSinceActivation = status.faultEventTimeSinceActivation,
+           let faultTimeStr = formatter.string(from: faultEventTimeSinceActivation)
+        {
+            result += String(format: LocalizedString("\nFault Time: %1$@", comment: "The format string for fault time: (1: fault time string)"), faultTimeStr)
+        }
+        if let errorEventInfo = status.errorEventInfo {
+            result += String(format: LocalizedString("\nFault Event Info: %1$03d (0x%2$02X),", comment: "The format string for fault event info: (1: fault event info)"), errorEventInfo.rawValue, errorEventInfo.rawValue)
+            result += String(format: LocalizedString("\n  Insulin State Table Corrupted: %@", comment: "The format string for insulin state table corrupted: (1: insulin state corrupted)"), String(describing: errorEventInfo.insulinStateTableCorruption))
+            result += String(format: LocalizedString("\n  Occlusion Type: %1$@", comment: "The format string for occlusion type: (1: occlusion type)"), String(describing: errorEventInfo.occlusionType))
+            result += String(format: LocalizedString("\n  Immediate Bolus In Progress: %1$@", comment: "The format string for immediate bolus in progress: (1: immediate bolus in progress)"), String(describing: errorEventInfo.immediateBolusInProgress))
+            result += String(format: LocalizedString("\n  Previous Pod Progress: %1$@", comment: "The format string for previous pod progress: (1: previous pod progress string)"), String(describing: errorEventInfo.podProgressStatus))
+        }
+        if let pdmRef = status.pdmRef {
+            result += String(format: LocalizedString("\nRef: %@", comment: "The Ref format string (1: pdm ref string)"), pdmRef)
+        }
+    }
+
+    return result
+}
+
+struct ReadPodStatusView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            let detailedStatus = try! DetailedStatus(encodedData: Data([0x02, 0x0d, 0x00, 0x00, 0x00, 0x0e, 0x00, 0xc3, 0x6a, 0x02, 0x07, 0x03, 0xff, 0x02, 0x09, 0x20, 0x00, 0x28, 0x00, 0x08, 0x00, 0x82]))
+            ReadPodStatusView() { completion in
+                completion(.success(detailedStatus))
+            }
+        }
+    }
+}

--- a/OmniBLE/PumpManagerUI/Views/SilencePodSelectionView.swift
+++ b/OmniBLE/PumpManagerUI/Views/SilencePodSelectionView.swift
@@ -1,30 +1,30 @@
 //
-//  BeepPreferenceSelectionView.swift
+//  SilencePodSelectionView.swift
 //  OmniBLE
 //
-//  Created by Pete Schwamb on 2/14/22.
-//  Copyright © 2022 LoopKit Authors. All rights reserved.
+//  Created by Joe Moran 8/30/23.
+//  Copyright © 2023 LoopKit Authors. All rights reserved.
 //
 
 import SwiftUI
 import LoopKit
 import LoopKitUI
 
-struct BeepPreferenceSelectionView: View {
+struct SilencePodSelectionView: View {
 
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
     @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
 
-    private var initialValue: BeepPreference
-    @State private var preference: BeepPreference
-    private var onSave: ((_ selectedValue: BeepPreference, _ completion: @escaping (_ error: LocalizedError?) -> Void) -> Void)?
+    private var initialValue: SilencePodPreference
+    @State private var preference: SilencePodPreference
+    private var onSave: ((_ selectedValue: SilencePodPreference, _ completion: @escaping (_ error: LocalizedError?) -> Void) -> Void)?
 
     @State private var alertIsPresented: Bool = false
     @State private var error: LocalizedError?
     @State private var saving: Bool = false
 
 
-    init(initialValue: BeepPreference, onSave: @escaping (_ selectedValue: BeepPreference, _ completion: @escaping (_ error: LocalizedError?) -> Void) -> Void) {
+    init(initialValue: SilencePodPreference, onSave: @escaping (_ selectedValue: SilencePodPreference, _ completion: @escaping (_ error: LocalizedError?) -> Void) -> Void) {
         self.initialValue = initialValue
         self._preference = State(initialValue: initialValue)
         self.onSave = onSave
@@ -38,12 +38,11 @@ struct BeepPreferenceSelectionView: View {
         VStack {
             List {
                 Section {
-                    Text(LocalizedString("Confidence reminders are beeps from the Pod which can be used to acknowledge selected commands when the Pod is not silenced.", comment: "Help text for BeepPreferenceSelectionView")).fixedSize(horizontal: false, vertical: true)
+                    Text(LocalizedString("Silence Pod mode suppresses all Pod alert and confirmation reminder beeping.", comment: "Help text for Silence Pod view")).fixedSize(horizontal: false, vertical: true)
                         .padding(.vertical, 10)
                 }
-
                 Section {
-                    ForEach(BeepPreference.allCases, id: \.self) { preference in
+                    ForEach(SilencePodPreference.allCases, id: \.self) { preference in
                         HStack {
                             CheckmarkListItem(
                                 title: Text(preference.title),
@@ -84,10 +83,9 @@ struct BeepPreferenceSelectionView: View {
             }
             .padding(self.horizontalSizeClass == .regular ? .bottom : [])
             .background(Color(UIColor.secondarySystemGroupedBackground).shadow(radius: 5))
-
         }
         .insetGroupedListStyle()
-        .navigationTitle(LocalizedString("Confidence Reminders", comment: "navigation title for confidence reminders"))
+        .navigationTitle(LocalizedString("Silence Pod", comment: "navigation title for Silnce Pod"))
         .navigationBarTitleDisplayMode(.inline)
         .alert(isPresented: $alertIsPresented, content: { alert(error: error) })
     }
@@ -109,15 +107,15 @@ struct BeepPreferenceSelectionView: View {
 
     private var cancelButton: some View {
         Button(action: { self.presentationMode.wrappedValue.dismiss() } ) {
-            Text(LocalizedString("Cancel", comment: "Button title for cancelling confidence reminders edit"))
+            Text(LocalizedString("Cancel", comment: "Button title for cancelling silence pod edit"))
         }
     }
 
     var saveButtonText: String {
         if saving {
-            return LocalizedString("Saving...", comment: "button title for saving confidence reminder while saving")
+            return LocalizedString("Saving...", comment: "button title for saving silence pod preference while saving")
         } else {
-            return LocalizedString("Save", comment: "button title for saving confidence reminder")
+            return LocalizedString("Save", comment: "button title for saving silence pod preference")
         }
     }
 
@@ -127,17 +125,16 @@ struct BeepPreferenceSelectionView: View {
 
     private func alert(error: Error?) -> SwiftUI.Alert {
         return SwiftUI.Alert(
-            title: Text(LocalizedString("Failed to update confidence reminder preference.", comment: "Alert title for error when updating confidence reminder preference")),
+            title: Text(LocalizedString("Failed to update silence pod preference.", comment: "Alert title for error when updating silence pod preference")),
             message: Text(error?.localizedDescription ?? "No Error")
         )
     }
-
 }
 
-struct BeepPreferenceSelectionView_Previews: PreviewProvider {
+struct SilencePodSelectionView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            BeepPreferenceSelectionView(initialValue: .extended) { selectedValue, completion in
+            SilencePodSelectionView(initialValue: .disabled) { selectedValue, completion in
                 print("Selected: \(selectedValue)")
                 completion(nil)
             }

--- a/OmniBLETests/AcknowledgeAlertsTests.swift
+++ b/OmniBLETests/AcknowledgeAlertsTests.swift
@@ -23,7 +23,7 @@ class AcknowledgeAlertsTests: XCTestCase {
             let cmd = try AcknowledgeAlertCommand(encodedData: Data(hexadecimalString: "11052f9b5b2f10")!)
             XCTAssertEqual(.acknowledgeAlert,cmd.blockType)
             XCTAssertEqual(0x2f9b5b2f, cmd.nonce)
-            XCTAssert(cmd.alerts.contains(.slot4))
+            XCTAssert(cmd.alerts.contains(.slot4LowReservoir))
         } catch (let error) {
             XCTFail("message decoding threw error: \(error)")
         }

--- a/OmniBLETests/MessageTests.swift
+++ b/OmniBLETests/MessageTests.swift
@@ -263,49 +263,49 @@ class MessageTests: XCTestCase {
         do {
             // Decode
             let status = try StatusResponse(encodedData: Data(hexadecimalString: "1d28008200004446ebff")!)
-            XCTAssert(status.alerts.contains(.slot3))
-            XCTAssert(status.alerts.contains(.slot7))
+            XCTAssert(status.alerts.contains(.slot3ExpirationReminder))
+            XCTAssert(status.alerts.contains(.slot7Expired))
         } catch (let error) {
             XCTFail("message decoding threw error: \(error)")
         }
     }
     
     func testConfigureAlertsCommand() {
-        // 79a4 10df 0502
-        // Pod expires 1 minute short of 3 days
-        let podSoftExpirationTime = TimeInterval(hours:72) - TimeInterval(minutes:1)
-        let alertConfig1 = AlertConfiguration(alertType: .slot7, active: true, autoOffModifier: false, duration: .hours(7), trigger: .timeUntilAlert(podSoftExpirationTime), beepRepeat: .every60Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
-        XCTAssertEqual("79a410df0502", alertConfig1.data.hexadecimalString)
+        // 020f 0000 0202
+        let alertConfig0 = AlertConfiguration(alertType: .slot0AutoOff, active: false, duration: .minutes(15), trigger: .timeUntilAlert(0), beepRepeat: .every1MinuteFor15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep, silent: false, autoOffModifier: true)
+        XCTAssertEqual("020f00000202", alertConfig0.data.hexadecimalString)
 
         // 2800 1283 0602
         let podHardExpirationTime = TimeInterval(hours:79) - TimeInterval(minutes:1)
-        let alertConfig2 = AlertConfiguration(alertType: .slot2, active: true, autoOffModifier: false, duration: .minutes(0), trigger: .timeUntilAlert(podHardExpirationTime), beepRepeat: .every15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
+        let alertConfig2 = AlertConfiguration(alertType: .slot2ShutdownImminent, active: true, duration: .minutes(0), trigger: .timeUntilAlert(podHardExpirationTime), beepRepeat: .every15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep, silent: false)
         XCTAssertEqual("280012830602", alertConfig2.data.hexadecimalString)
 
-        // 020f 0000 0202
-        let alertConfig3 = AlertConfiguration(alertType: .slot0, active: false, autoOffModifier: true, duration: .minutes(15), trigger: .timeUntilAlert(0), beepRepeat: .every1MinuteFor15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
-        XCTAssertEqual("020f00000202", alertConfig3.data.hexadecimalString)
-        
-        let configureAlerts = ConfigureAlertsCommand(nonce: 0xfeb6268b, configurations:[alertConfig1, alertConfig2, alertConfig3])
-        XCTAssertEqual("1916feb6268b79a410df0502280012830602020f00000202", configureAlerts.data.hexadecimalString)
-        
+        // 79a4 10df 0502
+        // Pod expires 1 minute short of 3 days
+        let podSoftExpirationTime = TimeInterval(hours:72) - TimeInterval(minutes:1)
+        let alertConfig7 = AlertConfiguration(alertType: .slot7Expired, active: true, duration: .hours(7), trigger: .timeUntilAlert(podSoftExpirationTime), beepRepeat: .every60Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep, silent: false)
+        XCTAssertEqual("79a410df0502", alertConfig7.data.hexadecimalString)
+
+        let configureAlerts = ConfigureAlertsCommand(nonce: 0xfeb6268b, configurations:[alertConfig0, alertConfig2, alertConfig7])
+        XCTAssertEqual("1916feb6268b020f0000020228001283060279a410df0502", configureAlerts.data.hexadecimalString)
+
         do {
             let decoded = try ConfigureAlertsCommand(encodedData: Data(hexadecimalString: "1916feb6268b79a410df0502280012830602020f00000202")!)
             XCTAssertEqual(3, decoded.configurations.count)
-            
+
             let config1 = decoded.configurations[0]
-            XCTAssertEqual(.slot7, config1.slot)
+            XCTAssertEqual(.slot7Expired, config1.slot)
             XCTAssertEqual(true, config1.active)
             XCTAssertEqual(false, config1.autoOffModifier)
             XCTAssertEqual(.hours(7), config1.duration)
-            if case AlertTrigger.timeUntilAlert(let duration) = config1.trigger {
-                XCTAssertEqual(podSoftExpirationTime, duration)
+            if case AlertTrigger.timeUntilAlert(let triggerTime) = config1.trigger {
+                XCTAssertEqual(podSoftExpirationTime, triggerTime)
             }
             XCTAssertEqual(.every60Minutes, config1.beepRepeat)
             XCTAssertEqual(.bipBeepBipBeepBipBeepBipBeep, config1.beepType)
-            
+
             let cfg = try AlertConfiguration(encodedData: Data(hexadecimalString: "4c0000640102")!)
-            XCTAssertEqual(.slot4, cfg.slot)
+            XCTAssertEqual(.slot4LowReservoir, cfg.slot)
             XCTAssertEqual(true, cfg.active)
             XCTAssertEqual(false, cfg.autoOffModifier)
             XCTAssertEqual(0, cfg.duration)
@@ -314,7 +314,6 @@ class MessageTests: XCTestCase {
             }
             XCTAssertEqual(.every1MinuteFor3MinutesAndRepeatEvery60Minutes, cfg.beepRepeat)
             XCTAssertEqual(.bipBeepBipBeepBipBeepBipBeep, cfg.beepType)
-
 
         } catch (let error) {
             XCTFail("message decoding threw error: \(error)")


### PR DESCRIPTION
This PR adds the Silent Pod and Pod Diagnostics features to the Omnipod screen for DASH pods:
* Prerequisite: LoopKit pull requests, OmniBLE PR 106, 114, 115, 116 and 117 should be merged first

The Silent Pod and Pod Diagnostics rows are only visible when allowDebugFeatures is true. This is configured using build-time flags in LoopWorkspace and is true by default for DIY Loop.

User-facing changes:
* Pod notifications include an option to silence the pod
   * When silenced, alerts are only on the phone, the pod does not beep
   * Pod faults, end of life and out of insulin still alarm on the pod regardless of this setting
* The previous pod row is moved under the pod details row to make it easier to find
* A pod diagnostics row is added to the end of the pod screen
   * various diagnostics rows are added in a new sub-screen
